### PR TITLE
updateDate wasn't calling onChange like setTime was

### DIFF
--- a/DateTime.js
+++ b/DateTime.js
@@ -217,7 +217,7 @@ var Datetime = React.createClass({
 			selectedDate: date,
 			viewDate: date.clone().startOf('month'),
 			inputValue: date.format( this.state.inputFormat )
-		});
+		}, this.callOnChange );
 	},
 
 	openCalendar: function() {


### PR DESCRIPTION
The `onChange` handler wasn't being triggered when in date-only operation and you clicked on a date in the calendar. It was getting triggered by typing though. This is because `updateDate` wasn't calling `onChange` like `setTime` is. Making them match fixes this issue.