### PR TITLE
Added a simulation of onBlur to enable final save events and the like

### DIFF
--- a/DateTime.js
+++ b/DateTime.js
@@ -22,6 +22,7 @@ var Datetime = React.createClass({
 	},
 	propTypes: {
 		date: TYPES.object,
+		onBlur: TYPES.func,
 		onChange: TYPES.func,
 		locale: TYPES.string,
 		input: TYPES.bool,
@@ -39,6 +40,7 @@ var Datetime = React.createClass({
 			viewMode: 'days',
 			inputProps: {},
 			input: true,
+			onBlur: function () {},
 			onChange: function (x) {
 				console.log(x);
 			}
@@ -225,6 +227,7 @@ var Datetime = React.createClass({
 	},
 
 	handleClickOutside: function(){
+		this.props.onBlur(this.state.inputValue);
 		if( this.props.input && this.state.open )
 			this.setState({ open: false });
 	},

--- a/DateTime.js
+++ b/DateTime.js
@@ -217,7 +217,7 @@ var Datetime = React.createClass({
 			selectedDate: date,
 			viewDate: date.clone().startOf('month'),
 			inputValue: date.format( this.state.inputFormat )
-		});
+		}, this.callOnChange );
 	},
 
 	openCalendar: function() {

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ API
 | **input** | boolean | true | Wether to show an input field to edit the date manually. |
 | **locale** | string | null | Manually set the locale for the react-datetime instance. Moment.js locale needs to be loaded to be used, see [i18n docs](#i18n).
 | **onChange** | function | x => console.log(x) | Callback trigger when the date changes |
+| **onBlur** | function | empty function | Callback trigger for when the user clicks outside of the input, simulating a regular onBlur |
 | **viewMode** | string or number | 'days' | The default view to display when the picker is shown. ('years', 'months', 'days', 'time') |
 | **inputProps** | object | undefined | Defines additional attributes for the input element of the component. |
 | **minDate** | moment | undefined | The earliest date allowed for entry in the calendar view. |


### PR DESCRIPTION
The new `onBlur` event is documented. It also has the same semantics as the `onChange` handler: it expects the latest value, rather than the event object.

This is intended to enable not needing to have more heavy-weight save events on every change, but rather saving it for when a user is done providing input.