### PR TITLE
Upgrade react-onclickoutside version to 0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,6 @@
   "dependencies": {
     "classlist-polyfill": "^1.0.1",
     "object-assign": "^3.0.0",
-    "react-onclickoutside": "^0.2.4"
+    "react-onclickoutside": "^0.3.0"
   }
 }


### PR DESCRIPTION
I was having trouble building with webpack due to an underlying [issue with react-onclickoutside that has since been fixed](https://github.com/Pomax/react-onclickoutside/issues/20). Using the newer 0.3.0, everything is in order.