### PR TITLE
Fix error when new year's days are showing up (December -> January)

### DIFF
--- a/src/DaysView.js
+++ b/src/DaysView.js
@@ -72,9 +72,9 @@ var DateTimePickerDays = React.createClass({
 			classes = 'day';
 			currentDate = prevMonth.clone();
 
-			if( prevMonth.year() < currentYear || prevMonth.month() < currentMonth )
+			if( ( prevMonth.year() == currentYear && prevMonth.month() < currentMonth ) || ( prevMonth.year() < currentYear ) )
 				classes += ' old';
-			else if( prevMonth.year() > currentYear || prevMonth.month() > currentMonth )
+			else if( ( prevMonth.year() == currentYear && prevMonth.month() > currentMonth ) || ( prevMonth.year() > currentYear ) )
 				classes += ' new';
 
 			if( selected && prevMonth.isSame( {y: selected.year(), M: selected.month(), d: selected.date()} ) )


### PR DESCRIPTION
It fixes the bug when it's December and you click in (supposedly) January days and it goes to November.