### PR TITLE
Add onFocus callback prop

### DIFF
--- a/DateTime.js
+++ b/DateTime.js
@@ -24,6 +24,7 @@ var Datetime = React.createClass({
 		// value: TYPES.object | TYPES.string,
 		// defaultValue: TYPES.object | TYPES.string,
 		onBlur: TYPES.func,
+		onFocus: TYPES.func,
 		onChange: TYPES.func,
 		locale: TYPES.string,
 		input: TYPES.bool,
@@ -252,6 +253,7 @@ var Datetime = React.createClass({
 
 	openCalendar: function() {
 		this.setState({ open: true });
+		this.props.onFocus();
 	},
 
 	handleClickOutside: function(){


### PR DESCRIPTION
I found it helpful to get a callback when the widget itself gains "focus". My use case is where I use two datetime pickers in tandem, and would like to be able to tab between them like normal inputs.