### PR TITLE
Make number of weeks in "days view" fluid, fixes #279

### DIFF
--- a/src/DaysView.js
+++ b/src/DaysView.js
@@ -67,8 +67,23 @@ var DateTimePickerDays = onClickOutside( createClass({
 			;
 
 		// Go to the last week of the previous month
-		prevMonth.date( prevMonth.daysInMonth() ).startOf( 'week' );
-		var lastDay = prevMonth.clone().add( 42, 'd' );
+		prevMonth.date( prevMonth.daysInMonth() );
+		// Prepend one calendar week if the month doesn't start at week start (Monday/Sunday)
+		if (prevMonth.weekday() === moment().endOf('week').weekday()) {
+			prevMonth.endOf( 'week' );
+			// Needed to account for the whole last day of the previous month
+			prevMonth.add( 1, 'd' );
+		} else {
+			prevMonth.startOf( 'week' );
+		}
+
+		var lastDay = date.clone().date( date.daysInMonth() );
+		// Append one extra calendar week only if the month doesn't end at week end (Sunday/Saturday)
+		if (lastDay.weekday() !== moment().endOf('week').weekday()) {
+			lastDay.add( 1, 'weeks' );
+		}
+		// Needed to account for the whole last day of the current month
+		lastDay.add( 1, 'd' );
 
 		while ( prevMonth.isBefore( lastDay ) ) {
 			classes = 'rdtDay';

--- a/test/__snapshots__/snapshots.spec.js.snap
+++ b/test/__snapshots__/snapshots.spec.js.snap
@@ -388,50 +388,6 @@ exports[`dateFormat set to true 1`] = `
               31
             </td>
           </tr>
-          <tr>
-            <td
-              className="rdtDay rdtNew"
-              data-value={1}
-              onClick={[Function]}>
-              1
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={2}
-              onClick={[Function]}>
-              2
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={3}
-              onClick={[Function]}>
-              3
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={4}
-              onClick={[Function]}>
-              4
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={5}
-              onClick={[Function]}>
-              5
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={6}
-              onClick={[Function]}>
-              6
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={7}
-              onClick={[Function]}>
-              7
-            </td>
-          </tr>
         </tbody>
         <tfoot>
           <tr>
@@ -731,50 +687,6 @@ exports[`input input: set to false 1`] = `
               data-value={31}
               onClick={[Function]}>
               31
-            </td>
-          </tr>
-          <tr>
-            <td
-              className="rdtDay rdtNew"
-              data-value={1}
-              onClick={[Function]}>
-              1
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={2}
-              onClick={[Function]}>
-              2
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={3}
-              onClick={[Function]}>
-              3
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={4}
-              onClick={[Function]}>
-              4
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={5}
-              onClick={[Function]}>
-              5
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={6}
-              onClick={[Function]}>
-              6
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={7}
-              onClick={[Function]}>
-              7
             </td>
           </tr>
         </tbody>
@@ -1086,50 +998,6 @@ exports[`input input: set to true 1`] = `
               31
             </td>
           </tr>
-          <tr>
-            <td
-              className="rdtDay rdtNew"
-              data-value={1}
-              onClick={[Function]}>
-              1
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={2}
-              onClick={[Function]}>
-              2
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={3}
-              onClick={[Function]}>
-              3
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={4}
-              onClick={[Function]}>
-              4
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={5}
-              onClick={[Function]}>
-              5
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={6}
-              onClick={[Function]}>
-              6
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={7}
-              onClick={[Function]}>
-              7
-            </td>
-          </tr>
         </tbody>
         <tfoot>
           <tr>
@@ -1437,50 +1305,6 @@ exports[`inputProps with className specified 1`] = `
               data-value={31}
               onClick={[Function]}>
               31
-            </td>
-          </tr>
-          <tr>
-            <td
-              className="rdtDay rdtNew"
-              data-value={1}
-              onClick={[Function]}>
-              1
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={2}
-              onClick={[Function]}>
-              2
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={3}
-              onClick={[Function]}>
-              3
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={4}
-              onClick={[Function]}>
-              4
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={5}
-              onClick={[Function]}>
-              5
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={6}
-              onClick={[Function]}>
-              6
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={7}
-              onClick={[Function]}>
-              7
             </td>
           </tr>
         </tbody>
@@ -1793,50 +1617,6 @@ exports[`inputProps with disabled specified 1`] = `
               31
             </td>
           </tr>
-          <tr>
-            <td
-              className="rdtDay rdtNew"
-              data-value={1}
-              onClick={[Function]}>
-              1
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={2}
-              onClick={[Function]}>
-              2
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={3}
-              onClick={[Function]}>
-              3
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={4}
-              onClick={[Function]}>
-              4
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={5}
-              onClick={[Function]}>
-              5
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={6}
-              onClick={[Function]}>
-              6
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={7}
-              onClick={[Function]}>
-              7
-            </td>
-          </tr>
         </tbody>
         <tfoot>
           <tr>
@@ -2145,50 +1925,6 @@ exports[`inputProps with name specified 1`] = `
               data-value={31}
               onClick={[Function]}>
               31
-            </td>
-          </tr>
-          <tr>
-            <td
-              className="rdtDay rdtNew"
-              data-value={1}
-              onClick={[Function]}>
-              1
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={2}
-              onClick={[Function]}>
-              2
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={3}
-              onClick={[Function]}>
-              3
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={4}
-              onClick={[Function]}>
-              4
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={5}
-              onClick={[Function]}>
-              5
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={6}
-              onClick={[Function]}>
-              6
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={7}
-              onClick={[Function]}>
-              7
             </td>
           </tr>
         </tbody>
@@ -2501,50 +2237,6 @@ exports[`inputProps with placeholder specified 1`] = `
               31
             </td>
           </tr>
-          <tr>
-            <td
-              className="rdtDay rdtNew"
-              data-value={1}
-              onClick={[Function]}>
-              1
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={2}
-              onClick={[Function]}>
-              2
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={3}
-              onClick={[Function]}>
-              3
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={4}
-              onClick={[Function]}>
-              4
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={5}
-              onClick={[Function]}>
-              5
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={6}
-              onClick={[Function]}>
-              6
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={7}
-              onClick={[Function]}>
-              7
-            </td>
-          </tr>
         </tbody>
         <tfoot>
           <tr>
@@ -2853,50 +2545,6 @@ exports[`inputProps with required specified 1`] = `
               data-value={31}
               onClick={[Function]}>
               31
-            </td>
-          </tr>
-          <tr>
-            <td
-              className="rdtDay rdtNew"
-              data-value={1}
-              onClick={[Function]}>
-              1
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={2}
-              onClick={[Function]}>
-              2
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={3}
-              onClick={[Function]}>
-              3
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={4}
-              onClick={[Function]}>
-              4
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={5}
-              onClick={[Function]}>
-              5
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={6}
-              onClick={[Function]}>
-              6
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={7}
-              onClick={[Function]}>
-              7
             </td>
           </tr>
         </tbody>
@@ -3208,50 +2856,6 @@ exports[`open set to false 1`] = `
               31
             </td>
           </tr>
-          <tr>
-            <td
-              className="rdtDay rdtNew"
-              data-value={1}
-              onClick={[Function]}>
-              1
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={2}
-              onClick={[Function]}>
-              2
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={3}
-              onClick={[Function]}>
-              3
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={4}
-              onClick={[Function]}>
-              4
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={5}
-              onClick={[Function]}>
-              5
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={6}
-              onClick={[Function]}>
-              6
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={7}
-              onClick={[Function]}>
-              7
-            </td>
-          </tr>
         </tbody>
         <tfoot>
           <tr>
@@ -3559,50 +3163,6 @@ exports[`open set to true 1`] = `
               data-value={31}
               onClick={[Function]}>
               31
-            </td>
-          </tr>
-          <tr>
-            <td
-              className="rdtDay rdtNew"
-              data-value={1}
-              onClick={[Function]}>
-              1
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={2}
-              onClick={[Function]}>
-              2
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={3}
-              onClick={[Function]}>
-              3
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={4}
-              onClick={[Function]}>
-              4
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={5}
-              onClick={[Function]}>
-              5
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={6}
-              onClick={[Function]}>
-              6
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={7}
-              onClick={[Function]}>
-              7
             </td>
           </tr>
         </tbody>
@@ -3914,50 +3474,6 @@ exports[`test className: set to arbitraty value 1`] = `
               31
             </td>
           </tr>
-          <tr>
-            <td
-              className="rdtDay rdtNew"
-              data-value={1}
-              onClick={[Function]}>
-              1
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={2}
-              onClick={[Function]}>
-              2
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={3}
-              onClick={[Function]}>
-              3
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={4}
-              onClick={[Function]}>
-              4
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={5}
-              onClick={[Function]}>
-              5
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={6}
-              onClick={[Function]}>
-              6
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={7}
-              onClick={[Function]}>
-              7
-            </td>
-          </tr>
         </tbody>
         <tfoot>
           <tr>
@@ -4265,50 +3781,6 @@ exports[`test defaultValue: set to arbitrary value 1`] = `
               data-value={31}
               onClick={[Function]}>
               31
-            </td>
-          </tr>
-          <tr>
-            <td
-              className="rdtDay rdtNew"
-              data-value={1}
-              onClick={[Function]}>
-              1
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={2}
-              onClick={[Function]}>
-              2
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={3}
-              onClick={[Function]}>
-              3
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={4}
-              onClick={[Function]}>
-              4
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={5}
-              onClick={[Function]}>
-              5
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={6}
-              onClick={[Function]}>
-              6
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={7}
-              onClick={[Function]}>
-              7
             </td>
           </tr>
         </tbody>
@@ -4620,50 +4092,6 @@ exports[`test everything default: renders correctly 1`] = `
               31
             </td>
           </tr>
-          <tr>
-            <td
-              className="rdtDay rdtNew"
-              data-value={1}
-              onClick={[Function]}>
-              1
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={2}
-              onClick={[Function]}>
-              2
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={3}
-              onClick={[Function]}>
-              3
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={4}
-              onClick={[Function]}>
-              4
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={5}
-              onClick={[Function]}>
-              5
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={6}
-              onClick={[Function]}>
-              6
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={7}
-              onClick={[Function]}>
-              7
-            </td>
-          </tr>
         </tbody>
         <tfoot>
           <tr>
@@ -4946,50 +4374,6 @@ exports[`test isValidDate: only valid if after yesterday 1`] = `
               data-value={31}
               onClick={[Function]}>
               31
-            </td>
-          </tr>
-          <tr>
-            <td
-              className="rdtDay rdtNew"
-              data-value={1}
-              onClick={[Function]}>
-              1
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={2}
-              onClick={[Function]}>
-              2
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={3}
-              onClick={[Function]}>
-              3
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={4}
-              onClick={[Function]}>
-              4
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={5}
-              onClick={[Function]}>
-              5
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={6}
-              onClick={[Function]}>
-              6
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={7}
-              onClick={[Function]}>
-              7
             </td>
           </tr>
         </tbody>
@@ -5301,50 +4685,6 @@ exports[`test renderDay: specified 1`] = `
               031
             </td>
           </tr>
-          <tr>
-            <td
-              className="rdtDay rdtNew"
-              data-value={1}
-              onClick={[Function]}>
-              01
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={2}
-              onClick={[Function]}>
-              02
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={3}
-              onClick={[Function]}>
-              03
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={4}
-              onClick={[Function]}>
-              04
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={5}
-              onClick={[Function]}>
-              05
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={6}
-              onClick={[Function]}>
-              06
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={7}
-              onClick={[Function]}>
-              07
-            </td>
-          </tr>
         </tbody>
         <tfoot>
           <tr>
@@ -5652,50 +4992,6 @@ exports[`test renderMonth: specified 1`] = `
               data-value={31}
               onClick={[Function]}>
               31
-            </td>
-          </tr>
-          <tr>
-            <td
-              className="rdtDay rdtNew"
-              data-value={1}
-              onClick={[Function]}>
-              1
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={2}
-              onClick={[Function]}>
-              2
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={3}
-              onClick={[Function]}>
-              3
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={4}
-              onClick={[Function]}>
-              4
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={5}
-              onClick={[Function]}>
-              5
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={6}
-              onClick={[Function]}>
-              6
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={7}
-              onClick={[Function]}>
-              7
             </td>
           </tr>
         </tbody>
@@ -6007,50 +5303,6 @@ exports[`test renderYear: specified 1`] = `
               31
             </td>
           </tr>
-          <tr>
-            <td
-              className="rdtDay rdtNew"
-              data-value={1}
-              onClick={[Function]}>
-              1
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={2}
-              onClick={[Function]}>
-              2
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={3}
-              onClick={[Function]}>
-              3
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={4}
-              onClick={[Function]}>
-              4
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={5}
-              onClick={[Function]}>
-              5
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={6}
-              onClick={[Function]}>
-              6
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={7}
-              onClick={[Function]}>
-              7
-            </td>
-          </tr>
         </tbody>
         <tfoot>
           <tr>
@@ -6358,50 +5610,6 @@ exports[`test value: set to arbitrary value 1`] = `
               data-value={31}
               onClick={[Function]}>
               31
-            </td>
-          </tr>
-          <tr>
-            <td
-              className="rdtDay rdtNew"
-              data-value={1}
-              onClick={[Function]}>
-              1
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={2}
-              onClick={[Function]}>
-              2
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={3}
-              onClick={[Function]}>
-              3
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={4}
-              onClick={[Function]}>
-              4
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={5}
-              onClick={[Function]}>
-              5
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={6}
-              onClick={[Function]}>
-              6
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={7}
-              onClick={[Function]}>
-              7
             </td>
           </tr>
         </tbody>
@@ -6713,50 +5921,6 @@ exports[`timeFormat set to false 1`] = `
               31
             </td>
           </tr>
-          <tr>
-            <td
-              className="rdtDay rdtNew"
-              data-value={1}
-              onClick={[Function]}>
-              1
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={2}
-              onClick={[Function]}>
-              2
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={3}
-              onClick={[Function]}>
-              3
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={4}
-              onClick={[Function]}>
-              4
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={5}
-              onClick={[Function]}>
-              5
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={6}
-              onClick={[Function]}>
-              6
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={7}
-              onClick={[Function]}>
-              7
-            </td>
-          </tr>
         </tbody>
       </table>
     </div>
@@ -7054,50 +6218,6 @@ exports[`timeFormat set to true 1`] = `
               data-value={31}
               onClick={[Function]}>
               31
-            </td>
-          </tr>
-          <tr>
-            <td
-              className="rdtDay rdtNew"
-              data-value={1}
-              onClick={[Function]}>
-              1
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={2}
-              onClick={[Function]}>
-              2
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={3}
-              onClick={[Function]}>
-              3
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={4}
-              onClick={[Function]}>
-              4
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={5}
-              onClick={[Function]}>
-              5
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={6}
-              onClick={[Function]}>
-              6
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={7}
-              onClick={[Function]}>
-              7
             </td>
           </tr>
         </tbody>
@@ -7407,50 +6527,6 @@ exports[`viewMode set to days 1`] = `
               data-value={31}
               onClick={[Function]}>
               31
-            </td>
-          </tr>
-          <tr>
-            <td
-              className="rdtDay rdtNew"
-              data-value={1}
-              onClick={[Function]}>
-              1
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={2}
-              onClick={[Function]}>
-              2
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={3}
-              onClick={[Function]}>
-              3
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={4}
-              onClick={[Function]}>
-              4
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={5}
-              onClick={[Function]}>
-              5
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={6}
-              onClick={[Function]}>
-              6
-            </td>
-            <td
-              className="rdtDay rdtNew"
-              data-value={7}
-              onClick={[Function]}>
-              7
             </td>
           </tr>
         </tbody>

--- a/test/testUtils.js
+++ b/test/testUtils.js
@@ -102,6 +102,10 @@ module.exports = {
 		return datetime.find('.rdtDay').at(n);
 	},
 
+	getActiveDay: (datetime) => {
+		return datetime.find('.rdtDay.rdtActive');
+	},
+
 	getNthMonth: (datetime, n) => {
 		return datetime.find('.rdtMonth').at(n);
 	},

--- a/test/tests.spec.js
+++ b/test/tests.spec.js
@@ -257,14 +257,16 @@ describe('Datetime', () => {
 	});
 
 	it('selected day persists (in UI) when navigating to prev month', () => {
-		const date = new Date(2000, 0, 3, 2, 2, 2, 2),
+		const date = new Date(2000, 0, 1, 2, 2, 2, 2),
 			component = utils.createDatetime({ viewMode: 'days', defaultValue: date });
 
 		utils.openDatepicker(component);
-		expect(utils.getNthDay(component, 8).hasClass('rdtActive')).toBeTruthy();
+		expect(utils.getNthDay(component, 6).hasClass('rdtActive')).toBeTruthy();
+		let dayNumber = utils.getNthDay(component, 6).text();
 		// Go to previous month
 		utils.clickOnElement(component.find('.rdtDays .rdtPrev span'));
-		expect(utils.getNthDay(component, 36).hasClass('rdtActive')).toBeTruthy();
+
+		expect(utils.getActiveDay(component).text() === dayNumber).toBeTruthy();
 	});
 
 	it('sets CSS class on today date', () => {
@@ -428,7 +430,7 @@ describe('Datetime', () => {
 			const component = utils.createDatetime({ value: mDate, renderDay: renderDayFn });
 
 			// Last day should be 6th of february
-			expect(currentDate.day()).toEqual(6);
+			expect(currentDate.day()).toEqual(1);
 			expect(currentDate.month()).toEqual(1);
 
 			// The date must be the same


### PR DESCRIPTION
## Description
Currently, the number of weeks in "days view" is fixed to 5 which causes most months to either have a whole week from the previous month or from the following month being rendered. This is unusual in most calendar UIs.
This change checks if the previous and current months end on the last day of the week (depends on the locale set in momentJS) to decide if an extra week is necessary.
This also fixes tests to take this change into account.

So this:
![image](https://cloud.githubusercontent.com/assets/2715751/25898541/d8ff7b06-358c-11e7-9279-39b9168da2c4.png)

Becomes this:
![image](https://cloud.githubusercontent.com/assets/2715751/25898558/eb8533a6-358c-11e7-9638-3be101ec19c1.png)

And this:
![image](https://cloud.githubusercontent.com/assets/2715751/25898594/102635ac-358d-11e7-90dd-f2c9db9cd54e.png)

Becomes this:
![image](https://cloud.githubusercontent.com/assets/2715751/25900131/ab0118ee-3592-11e7-9ca7-bfb64027d23a.png)


### Motivation and Context
Fixes #279 
Follow up of #327 after cleaning up conflicts

### Checklist

[x] I have added (changed) tests covering my changes
[x] All new and existing tests pass
[ ] My changes required the documentation to be updated

_Please let me know if this is something you would like to see merged. It would be useful to me and we're [using it in production atm](https://github.com/simplesurance/react-datetime)._