### PR TITLE
Only call hooks when setState has finished updating the internal state

### DIFF
--- a/DateTime.js
+++ b/DateTime.js
@@ -235,8 +235,10 @@ var Datetime = createClass({
 	showView: function( view ) {
 		var me = this;
 		return function() {
-			me.state.currentView !== view && me.props.onViewModeChange( view );
-			me.setState({ currentView: view });
+			var previousView = me.state.currentView;
+			me.setState({ currentView: view }, function() {
+				previousView !== view && me.props.onViewModeChange( view );
+			});
 		};
 	},
 
@@ -251,34 +253,37 @@ var Datetime = createClass({
 			me.setState({
 				viewDate: me.state.viewDate.clone()[ type ]( parseInt(e.target.getAttribute('data-value'), 10) ).startOf( type ),
 				currentView: nextViews[ type ]
+			}, function() {
+				me.props.onViewModeChange( nextViews[ type ] );
 			});
-			me.props.onViewModeChange( nextViews[ type ] );
 		};
 	},
 
 	subtractTime: function( amount, type, toSelected ) {
 		var me = this;
 		return function() {
-			me.props.onNavigateBack( amount, type );
-			me.updateTime( 'subtract', amount, type, toSelected );
+			me.updateTime( 'subtract', amount, type, toSelected, function() {
+				me.props.onNavigateBack( amount, type );
+			});
 		};
 	},
 
 	addTime: function( amount, type, toSelected ) {
 		var me = this;
 		return function() {
-			me.props.onNavigateForward( amount, type );
-			me.updateTime( 'add', amount, type, toSelected );
+			me.updateTime( 'add', amount, type, toSelected, function() {
+				me.props.onNavigateForward( amount, type );
+			});
 		};
 	},
 
-	updateTime: function( op, amount, type, toSelected ) {
+	updateTime: function( op, amount, type, toSelected, callback ) {
 		var update = {},
 			date = toSelected ? 'selectedDate' : 'viewDate';
 
 		update[ date ] = this.state[ date ].clone()[ op ]( amount, type );
 
-		this.setState( update );
+		this.setState( update, callback );
 	},
 
 	allowedSetTime: ['hours', 'minutes', 'seconds', 'milliseconds'],

--- a/test/.eslintrc.js
+++ b/test/.eslintrc.js
@@ -1,6 +1,6 @@
 module.exports = {
 		"parserOptions": {
-				"ecmaVersion": 6,
+				"ecmaVersion": 2017,
 				"sourceType": "module",
 				"ecmaFeatures": {
 						"jsx": true

--- a/test/tests.spec.js
+++ b/test/tests.spec.js
@@ -1,4 +1,4 @@
-/* global it, xit, describe, expect, jasmine, done, jest */
+/* global it, xit, describe, expect, jasmine, done, jest, Promise */
 
 import React from 'react'; // eslint-disable-line no-unused-vars
 import moment from 'moment';
@@ -946,7 +946,7 @@ describe('Datetime', () => {
 			expect(onFocusFn).toHaveBeenCalledTimes(1);
 		});
 
-		describe('onViewModeChange', () => {
+		describe('onViewModeChange', async () => {
 			it('when switch from days to time view mode', () => {
 				const component = utils.createDatetime({ onViewModeChange: (viewMode) => {
 					expect(viewMode).toEqual('time');
@@ -956,51 +956,65 @@ describe('Datetime', () => {
 				expect(utils.isTimeView(component)).toBeTruthy();
 			});
 
-			it('when switch from time to days view mode', () => {
+			it('when switch from time to days view mode', async () => {
 				const component = utils.createDatetime({ viewMode: 'time', onViewModeChange: (viewMode) => {
 					expect(viewMode).toEqual('days');
 				}});
 				expect(utils.isTimeView(component)).toBeTruthy();
 				utils.clickOnElement(component.find('.rdtSwitch'));
+				await Promise.resolve();
 				expect(utils.isDayView(component)).toBeTruthy();
 			});
 
-			it('when switch from days to months view mode', () => {
+			it('when switch from days to months view mode', async () => {
 				const component = utils.createDatetime({ onViewModeChange: (viewMode) => {
 					expect(viewMode).toEqual('months');
 				}});
 				expect(utils.isDayView(component)).toBeTruthy();
 				utils.clickOnElement(component.find('.rdtSwitch'));
+				await Promise.resolve();
 				expect(utils.isMonthView(component)).toBeTruthy();
 			});
 
-			it('when switch from months to years view mode', () => {
+			it('when switch from months to years view mode', async () => {
 				const component = utils.createDatetime({ viewMode: 'months', onViewModeChange: (viewMode) => {
 					expect(viewMode).toEqual('years');
 				}});
 				expect(utils.isMonthView(component)).toBeTruthy();
 				utils.clickOnElement(component.find('.rdtSwitch'));
+				await Promise.resolve();
 				expect(utils.isYearView(component)).toBeTruthy();
 			});
 
-			it('only when switch from years to months view mode', () => {
+			it('only when switch from years to months view mode', async () => {
 				const component = utils.createDatetime({ viewMode: 'years', onViewModeChange: (viewMode) => {
 					expect(viewMode).toEqual('months');
 				}});
 				expect(utils.isYearView(component)).toBeTruthy();
 				utils.clickOnElement(component.find('.rdtSwitch'));
+				await Promise.resolve();
 				expect(utils.isYearView(component)).toBeTruthy();
 				utils.clickNthYear(component, 2);
 				expect(utils.isMonthView(component)).toBeTruthy();
 			});
 
-			it('when switch from months to days view mode', () => {
+			it('when switch from months to days view mode', async () => {
 				const component = utils.createDatetime({ viewMode: 'months', onViewModeChange: (viewMode) => {
 					expect(viewMode).toEqual('days');
 				}});
 				expect(utils.isMonthView(component)).toBeTruthy();
 				utils.clickNthMonth(component, 2);
+				await Promise.resolve();
 				expect(utils.isDayView(component)).toBeTruthy();
+			});
+
+			it('receives the callback only after the currentView state has been set', async () => {
+				const component = utils.createDatetime({ onViewModeChange: () => {
+					expect(component.state('currentView')).toEqual('time');
+				}});
+
+				utils.clickOnElement(component.find('.rdtTimeToggle'));
+				await Promise.resolve();
 			});
 		});
 
@@ -1088,60 +1102,110 @@ describe('Datetime', () => {
 	});
 
 	describe('onNavigateForward', () => {
-		it('when moving to next month', () => {
+		it('is being called', async () => {
+			const callback = jest.fn();
+			const component = utils.createDatetime({ onNavigateForward: callback });
+			utils.clickOnElement(component.find('.rdtNext'));
+
+			await Promise.resolve();
+			expect(callback).toBeCalled();
+		});
+
+		it('when moving to next month', async () => {
 			const component = utils.createDatetime({ onNavigateForward: (amount, type) => {
 				expect(amount).toEqual(1);
 				expect(type).toEqual('months');
 			}});
 
 			utils.clickOnElement(component.find('.rdtNext'));
+			await Promise.resolve();
 		});
 
-		it('when moving to next year', () => {
+		it('when moving to next year', async () => {
 			const component = utils.createDatetime({ viewMode: 'months', onNavigateForward: (amount, type) => {
 				expect(amount).toEqual(1);
 				expect(type).toEqual('years');
 			}});
 
 			utils.clickOnElement(component.find('.rdtNext'));
+			await Promise.resolve();
 		});
 
-		it('when moving decade forward', () => {
+		it('when moving decade forward', async () => {
 			const component = utils.createDatetime({ viewMode: 'years', onNavigateForward: (amount, type) => {
 				expect(amount).toEqual(10);
 				expect(type).toEqual('years');
 			}});
 
 			utils.clickOnElement(component.find('.rdtNext'));
+			await Promise.resolve();
+		});
+
+		it('receives the callback only after the viewDate state has been set', async () => {
+			let date;
+			const component = utils.createDatetime({ onNavigateForward: () => {
+				expect(component.state('viewDate').isSame(date)).toEqual(true);
+			}});
+
+			date = component.state('viewDate').clone();
+			date.add(1, 'months');
+
+			utils.clickOnElement(component.find('.rdtNext'));
+			await Promise.resolve();
 		});
 	});
 
 	describe('onNavigateBack', () => {
-		it('when moving to previous month', () => {
+		it('is being called', async () => {
+			const callback = jest.fn();
+			const component = utils.createDatetime({ onNavigateBack: callback });
+			utils.clickOnElement(component.find('.rdtPrev'));
+
+			await Promise.resolve();
+			expect(callback).toBeCalled();
+		});
+
+		it('when moving to previous month', async () => {
 			const component = utils.createDatetime({ onNavigateBack: (amount, type) => {
 				expect(amount).toEqual(1);
 				expect(type).toEqual('months');
 			}});
 
 			utils.clickOnElement(component.find('.rdtPrev'));
+			await Promise.resolve();
 		});
 
-		it('when moving to previous year', () => {
+		it('when moving to previous year', async () => {
 			const component = utils.createDatetime({ viewMode: 'months', onNavigateBack: (amount, type) => {
 				expect(amount).toEqual(1);
 				expect(type).toEqual('years');
 			}});
 
 			utils.clickOnElement(component.find('.rdtPrev'));
+			await Promise.resolve();
 		});
 
-		it('when moving decade back', () => {
+		it('when moving decade back', async () => {
 			const component = utils.createDatetime({ viewMode: 'years', onNavigateBack: (amount, type) => {
 				expect(amount).toEqual(10);
 				expect(type).toEqual('years');
 			}});
 
 			utils.clickOnElement(component.find('.rdtPrev'));
+			await Promise.resolve();
+		});
+
+		it('receives the callback only after the viewDate state has been set', async () => {
+			let date;
+			const component = utils.createDatetime({ onNavigateBack: () => {
+				expect(component.state('viewDate').isSame(date)).toEqual(true);
+			}});
+
+			date = component.state('viewDate').clone();
+			date.subtract(1, 'months');
+
+			utils.clickOnElement(component.find('.rdtPrev'));
+			await Promise.resolve();
 		});
 	});
 


### PR DESCRIPTION
### Description
Before this, when a hook like `onViewModeChange`, `onNavigateBack` or `onNavigateForward` was called, the internal state would not yet be updated. This meant that when I tried to access the current `viewDate` through the internal state after one of these hooks was called, the setState would not have been updated yet, because `setState` is asynchronous. This PR only calls these hooks when `setState` has completed.

### Checklist
```
[x] I have not included any built dist files (us maintainers do that prior to a new release)
[x] I have added tests covering my changes
[x] All new and existing tests pass
[ ] My changes required the documentation to be updated
  [ ] I have updated the documentation accordingly
  [ ] I have updated the TypeScript 1.8 type definitions accordingly
  [ ] I have updated the TypeScript 2.0+ type definitions accordingly
```

The tests had to be refactored a bit. I had to implement an async/await pattern that waits for the `setState` to complete before moving on to the next test. For some reason all tests within the hooks are ignored without the async/await pattern. This also meant I had to upgrade the eslint and the eslint parser for the tests to ES2017. This also meant I had to fix some issues in the code itself.