### PR TITLE
Close on selection of month instead of year when dateFormat is set to display quarter

### DIFF
--- a/DateTime.js
+++ b/DateTime.js
@@ -105,7 +105,7 @@ var Datetime = createClass({
 	getUpdateOn: function( formats ) {
 		if ( formats.date.match(/[lLD]/) ) {
 			return viewModes.DAYS;
-		} else if ( formats.date.indexOf('M') !== -1 ) {
+		} else if ( formats.date.match(/[MQ]/) ) {
 			return viewModes.MONTHS;
 		} else if ( formats.date.indexOf('Y') !== -1 ) {
 			return viewModes.YEARS;

--- a/test/tests.spec.js
+++ b/test/tests.spec.js
@@ -1055,10 +1055,33 @@ describe('Datetime', () => {
 				utils.clickNthDay(component, 9);
 			});
 
+			it('when selecting date with week of year in dateFormat', (done) => {
+				const date = new Date(2000, 0, 15, 2, 2, 2, 2),
+					mDate = moment(date),
+					component = utils.createDatetime({ defaultValue: date, dateFormat: 'gggg-[W]ww', onChange: (selected) => {
+						expect(selected.date()).toEqual(2);
+						expect(selected.month()).toEqual(mDate.month());
+						expect(selected.year()).toEqual(mDate.year());
+						done();
+					}});
+
+				utils.clickNthDay(component, 7);
+			});
+
 			it('when selecting month', () => {
 				const date = Date.UTC(2000, 0, 15, 2, 2, 2, 2),
 					onChangeFn = jest.fn(),
 					component = utils.createDatetime({ defaultValue: date, dateFormat: 'YYYY-MM', onChange: onChangeFn });
+
+				utils.clickNthMonth(component, 2);
+				expect(onChangeFn).toHaveBeenCalledTimes(1);
+				expect(onChangeFn.mock.calls[0][0].toJSON()).toEqual('2000-03-15T02:02:02.002Z');
+			});
+
+			it('when selecting month with quarter in dateFormat', () => {
+				const date = Date.UTC(2000, 0, 15, 2, 2, 2, 2),
+					onChangeFn = jest.fn(),
+					component = utils.createDatetime({ defaultValue: date, dateFormat: 'YYYY-[Q]Q', onChange: onChangeFn });
 
 				utils.clickNthMonth(component, 2);
 				expect(onChangeFn).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
### Description

Altered getUpdateOn() method to return viewModes.MONTHS when Q token is used in dateFormat. In case of dateFormats like YYYY-[Q]Q, it would detect Y token and return 'years' instead, but month selection is required to specify a quarter of a year.

Added a test case to cover this but also one to cover behaviour when w token is used (week of year), which is handled correctly even though it's not explicitly matched because getUpdateOn() returns viewModes.DAY by default.

### Motivation and Context

My team ran into this problem while using react-datetime with closeOnSelect=true to control data for rendering of charts in which date grain can also be selected in another component. Changing date grain updates dateFormat prop on datepickers. It works fine for all formats except YYYY-[Q]Q where it closes when year is selected, making it impossible for user to get to months view.

Also added a test case to check week of the year format (for example gggg-[W]ww), which is also something we use. This is currently working correctly because all token detection fail and the method returns 'days' by default. I feel however that it would be easy to break with future changes since it relies on the default return, hence a new test case.

### Checklist

```
[ x ] I have not included any built dist files (us maintainers do that prior to a new release)
[ x ] I have added tests covering my changes
[ x ] All new and existing tests pass
[ ] My changes required the documentation to be updated
  [ ] I have updated the documentation accordingly
  [ ] I have updated the TypeScript 1.8 type definitions accordingly
  [ ] I have updated the TypeScript 2.0+ type definitions accordingly
```