### PR TITLE
Adding renderInput to typescript definition

### DIFF
--- a/DateTime.d.ts
+++ b/DateTime.d.ts
@@ -146,6 +146,14 @@ declare namespace ReactDatetimeClass {
          */
         renderYear?: (props: any, year: number, selectedDate: any) => JSX.Element;
         /*
+         Customize the way that the Input is shown.
+         The accepted function has openCalendar (a function which opens the calendar),
+         closeCalendar (a function which closes the calendar), and
+         the default calculated props for the input. Must return a React component or null.
+         See appearance customization
+         */
+        renderInput?: (props: any, openCalendar: Function, closeCalendar: Function) => JSX.Element;
+        /*
          Whether to use moment's strict parsing when parsing input.
          */
         strictParsing?: boolean;


### PR DESCRIPTION
Adding renderInput to typescript definition

### Description
See above, simple as that.  Includes props, openCalendar, closeCalendar, and description.

### Motivation and Context
Missed definition -> see #482

### Checklist
<!--
  The purpose of this checklist is for you to not forget changes you most likely should do. Look 
  through the following points, and put an "x" in all the boxes that apply. If you're unsure about 
  any of these points, then we'd recommend you to read the README. If something still is unclear 
  then don't hesitate to ask. We're here to help!
-->
```
[ ] I have not included any built dist files (us maintainers do that prior to a new release)
[ ] I have added tests covering my changes
[ ] All new and existing tests pass - looks like some tests are failing due to failure to update a snapshot, if this is a huge issue, can just submit it with a new snapshot, but feel like that'd be something covered by a different PR?
[ ] My changes required the documentation to be updated
  [ ] I have updated the documentation accordingly
  [ ] I have updated the TypeScript 1.8 type definitions accordingly
  [ ] I have updated the TypeScript 2.0+ type definitions accordingly
```


<!--
  Is there anything in this template you think is confusing, unclear, redundant or just simply bad?
  Please let us know either via creating an issue or creating a PR with changes to it.
-->
