### PR TITLE
Added renderInput definition to typings

### DIFF
--- a/DateTime.d.ts
+++ b/DateTime.d.ts
@@ -121,6 +121,12 @@ declare namespace ReactDatetimeClass {
          */
         inputProps?: React.HTMLProps<HTMLInputElement>;
         /*
+         Replace the rendering of the input element. The accepted function has openCalendar
+         (a function which opens the calendar) and the default calculated props for the input.
+         Must return a React component or null.
+        */
+        renderInput?: (props: Object, openCalendar: Function) => React.Component<any, any>;
+        /*
          Define the dates that can be selected. The function receives (currentDate, selectedDate)
          and should return a true or false whether the currentDate is valid or not. See selectable dates.
          */

--- a/DateTime.d.ts
+++ b/DateTime.d.ts
@@ -122,10 +122,10 @@ declare namespace ReactDatetimeClass {
         inputProps?: React.HTMLProps<HTMLInputElement>;
         /*
          Replace the rendering of the input element. The accepted function has openCalendar
-         (a function which opens the calendar) and the default calculated props for the input.
-         Must return a React component or null.
+         (a function which opens the calendar), closeCalendar (a function which opens the calendar)
+         and the default calculated props for the input. Must return a React component or null.
         */
-        renderInput?: (props: Object, openCalendar: Function) => React.Component<any, any>;
+        renderInput?: (props: Object, openCalendar: Function, closeCalendar: Function) => JSX.Element;
         /*
          Define the dates that can be selected. The function receives (currentDate, selectedDate)
          and should return a true or false whether the currentDate is valid or not. See selectable dates.


### PR DESCRIPTION
### Description
Added missing renderInput property to typings

### Motivation and Context
Solves typescript 2.0+ errors when trying to use renderInput prop.

### Checklist
```
[x] I have not included any built dist files (us maintainers do that prior to a new release)
[ ] I have added tests covering my changes
[x] All new and existing tests pass
[ ] My changes required the documentation to be updated
  [ ] I have updated the documentation accordingly
  [ ] I have updated the TypeScript 1.8 type definitions accordingly
  [x] I have updated the TypeScript 2.0+ type definitions accordingly
```
