### PR TITLE
Add renderInput property to definition

### DIFF
--- a/DateTime.d.ts
+++ b/DateTime.d.ts
@@ -121,6 +121,12 @@ declare namespace ReactDatetimeClass {
          */
         inputProps?: React.HTMLProps<HTMLInputElement>;
         /*
+         Replace the rendering of the input element. The accepted function has openCalendar 
+         (a function which opens the calendar) and the default calculated props for the input. 
+         Must return a React component or null.
+        */
+        renderInput?: (props: any, openCalendar: Function) => JSX.Element;
+        /*
          Define the dates that can be selected. The function receives (currentDate, selectedDate)
          and should return a true or false whether the currentDate is valid or not. See selectable dates.
          */
@@ -177,4 +183,4 @@ declare namespace ReactDatetimeClass {
     }
 }
 
-declare class ReactDatetimeClass extends Component<ReactDatetimeClass.DatetimepickerProps, ReactDatetimeClass.DatetimepickerState> {}
+declare class ReactDatetimeClass extends Component<ReactDatetimeClass.DatetimepickerProps, ReactDatetimeClass.DatetimepickerState> { }


### PR DESCRIPTION
In the current version the renderInput property is missing in the definitions. 
For adding custom Rendering (for example Material Ui Input)  we need you to provide that property in the typings.
Works fine with edited typings, see: 
![image](https://user-images.githubusercontent.com/10747768/37609727-2dc67542-2b9e-11e8-9905-4178db2f536d.png)
