### PR TITLE
Add renderInput to TypeScript definition

### DIFF
--- a/DateTime.d.ts
+++ b/DateTime.d.ts
@@ -132,6 +132,13 @@ declare namespace ReactDatetimeClass {
          */
         renderDay?: (props: any, currentDate: any, selectedDate: any) => JSX.Element;
         /*
+         Replace the rendering of the input element. The function has the following arguments:
+         the default calculated props for the input, openCalendar (a function which opens the calendar)
+         and closeCalendar (a function which closes the calendar).
+         Must return a React component or null. See input customization
+         */
+        renderInput?: (props: any, openCalendar: () => void, closeCalendar: () => void) => void;
+        /*
          Customize the way that the months are shown in the month picker.
          The accepted function has the selectedDate, the current date and the default calculated
          props for the cell, the month and the year to be shown, and must return a


### PR DESCRIPTION
### Description
I added the following definition of the `renderInput` prop to the TypeScript definition file:
```typescript
renderInput?: (props: any, openCalendar: () => void, closeCalendar: () => void) => void;
```

### Motivation and Context
* This pull request is made because I used to work with this project for a TypeScript-based application and I see that the definition for the `renderInput` prop was missing, causing my project to fail transpiling.
* I think it should be merged to help other people like me, who are using the TypeScript version of the component and that want to use this prop.

### Checklist
```
[x] I have not included any built dist files (us maintainers do that prior to a new release)
[ ] I have added tests covering my changes
[ ] All new and existing tests pass
[ ] My changes required the documentation to be updated
  [ ] I have updated the documentation accordingly
  [ ] I have updated the TypeScript 1.8 type definitions accordingly
  [ ] I have updated the TypeScript 2.0+ type definitions accordingly
```

