### PR TITLE
Issue #550: Re-Rendering With Unchanged Props

### DIFF
--- a/DateTime.js
+++ b/DateTime.js
@@ -141,12 +141,29 @@ var Datetime = createClass({
 		return formats;
 	},
 
+	areEquivalentDates: function( currentDate, nextDate ) {
+		if (!currentDate && !nextDate) {
+			return true;
+		} else if ((!currentDate && nextDate) || (currentDate && !nextDate)) {
+			return false;
+		}
+		if (typeof currentDate === 'string' && typeof nextDate === 'string') {
+			return currentDate === nextDate;
+		} else if (currentDate instanceof Date && nextDate instanceof Date) {
+			return currentDate.getTime() === nextDate.getTime();
+		} else if ((currentDate instanceof moment) && (nextDate instanceof moment)) {
+			return currentDate.isSame(nextDate);
+		}
+		return false;
+	},
+
 	componentWillReceiveProps: function( nextProps ) {
 		var formats = this.getFormats( nextProps ),
-			updatedState = {}
-		;
+			updatedState = {},
+			valueChanged = !this.areEquivalentDates(this.props.value, nextProps.value)
+			;
 
-		if ( nextProps.value !== this.props.value ||
+		if ( valueChanged ||
 			formats.datetime !== this.getFormats( this.props ).datetime ) {
 			updatedState = this.getStateFromProps( nextProps );
 		}
@@ -154,7 +171,7 @@ var Datetime = createClass({
 		if ( updatedState.open === undefined ) {
 			if ( typeof nextProps.open !== 'undefined' ) {
 				updatedState.open = nextProps.open;
-			} else if ( this.props.closeOnSelect && this.state.currentView !== viewModes.TIME ) {
+			} else if ( this.props.closeOnSelect && this.state.currentView !== viewModes.TIME && valueChanged ) {
 				updatedState.open = false;
 			} else {
 				updatedState.open = this.state.open;

--- a/test/tests.spec.js
+++ b/test/tests.spec.js
@@ -747,38 +747,77 @@ describe('Datetime', () => {
 			expect(actualMonths).toEqual(expectedMonths);
 		});
 
-		it('closeOnSelect=false', (done) => {
-			const component = utils.createDatetime({ closeOnSelect: false });
+		describe('closeOnSelect', () => {
+			it('closeOnSelect=false', (done) => {
+				const component = utils.createDatetime({ closeOnSelect: false });
 
-			// A unknown race condition is causing this test to fail without this time out,
-			// and when the test fails it says:
-			// 'Timeout - Async callback was not invoked within timeout'
-			// Ideally it would say something else but at least we know the tests are passing now
-			setTimeout(() => {
-				expect(utils.isOpen(component)).toBeFalsy();
-				utils.openDatepicker(component);
-				expect(utils.isOpen(component)).toBeTruthy();
-				utils.clickNthDay(component, 2);
-				expect(utils.isOpen(component)).toBeTruthy();
-				done();
-			}, 0);
-		});
+				// A unknown race condition is causing this test to fail without this time out,
+				// and when the test fails it says:
+				// 'Timeout - Async callback was not invoked within timeout'
+				// Ideally it would say something else but at least we know the tests are passing now
+				setTimeout(() => {
+					expect(utils.isOpen(component)).toBeFalsy();
+					utils.openDatepicker(component);
+					expect(utils.isOpen(component)).toBeTruthy();
+					utils.clickNthDay(component, 2);
+					expect(utils.isOpen(component)).toBeTruthy();
+					done();
+				}, 0);
+			});
 
-		it('closeOnSelect=true', (done) => {
-			const component = utils.createDatetime({ closeOnSelect: true });
+			it('closeOnSelect=true', (done) => {
+				const component = utils.createDatetime({ closeOnSelect: true });
 
-			// A unknown race condition is causing this test to fail without this time out,
-			// and when the test fails it says:
-			// 'Timeout - Async callback was not invoked within timeout'
-			// Ideally it would say something else but at least we know the tests are passing now
-			setTimeout(() => {
-				expect(utils.isOpen(component)).toBeFalsy();
-				utils.openDatepicker(component);
-				expect(utils.isOpen(component)).toBeTruthy();
-				utils.clickNthDay(component, 2);
-				expect(utils.isOpen(component)).toBeFalsy();
-				done();
-			}, 0);
+				// A unknown race condition is causing this test to fail without this time out,
+				// and when the test fails it says:
+				// 'Timeout - Async callback was not invoked within timeout'
+				// Ideally it would say something else but at least we know the tests are passing now
+				setTimeout(() => {
+					expect(utils.isOpen(component)).toBeFalsy();
+					utils.openDatepicker(component);
+					expect(utils.isOpen(component)).toBeTruthy();
+					utils.clickNthDay(component, 2);
+					expect(utils.isOpen(component)).toBeFalsy();
+					done();
+				}, 0);
+			});
+
+			it('closes the calendar when re-redering if the date was changed', (done) => {
+				const component = utils.createDatetime({ closeOnSelect: true });
+
+				// A unknown race condition is causing this test to fail without this time out,
+				// and when the test fails it says:
+				// 'Timeout - Async callback was not invoked within timeout'
+				// Ideally it would say something else but at least we know the tests are passing now
+				setTimeout(() => {
+					expect(utils.isOpen(component)).toBeFalsy();
+					utils.openDatepicker(component);
+					expect(utils.isOpen(component)).toBeTruthy();
+					const date = new Date(2000, 0, 15, 2, 2, 2, 2);
+					component.setProps({ closeOnSelect: true, value: date }, () => {
+						expect(utils.isOpen(component)).toBeFalsy();
+						done();
+					});
+				}, 0);
+			});
+
+			it('does NOT close the calendar when re-redering if props are unchanged', (done) => {
+				const component = utils.createDatetime({ closeOnSelect: true });
+
+				// A unknown race condition is causing this test to fail without this time out,
+				// and when the test fails it says:
+				// 'Timeout - Async callback was not invoked within timeout'
+				// Ideally it would say something else but at least we know the tests are passing now
+				setTimeout(() => {
+					expect(utils.isOpen(component)).toBeFalsy();
+					utils.openDatepicker(component);
+					expect(utils.isOpen(component)).toBeTruthy();
+					component.setProps(component.props, () => {
+						expect(utils.isOpen(component)).toBeTruthy();
+						done();
+					});
+				}, 0);
+			});
 		});
 
 		describe('defaultValue of type', () => {


### PR DESCRIPTION
### Description
Updates the componentWillReceiveProps function to leave the calendar open when the closeOnSelect prop is set but the value was unchanged.

### Motivation and Context
Addresses issue outlined in #550.

### Checklist
```
[x] I have not included any built dist files (us maintainers do that prior to a new release)
[x] I have added tests covering my changes
[x] All new and existing tests pass
[ ] My changes required the documentation to be updated
  [ ] I have updated the documentation accordingly
  [ ] I have updated the TypeScript 1.8 type definitions accordingly
  [ ] I have updated the TypeScript 2.0+ type definitions accordingly
```
