### PR TITLE
Add support for locale-aware time formats (LT, LTS)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-datetime",
-  "version": "2.10.3",
+  "version": "2.14.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/TimeView.js
+++ b/src/TimeView.js
@@ -3,6 +3,7 @@
 var React = require('react'),
 	createClass = require('create-react-class'),
 	assign = require('object-assign'),
+	moment = require('moment'),
 	onClickOutside = require('react-onclickoutside').default
 	;
 
@@ -11,9 +12,18 @@ var DateTimePickerTime = onClickOutside( createClass({
 		return this.calculateState( this.props );
 	},
 
+	getLocalizedFormat: function( format ) {
+		var passedLocale = (this.props.localMoment().localeData()._abbr);
+		if ( format.indexOf('L') !== -1 ) {
+			return new moment().locale(passedLocale).localeData()._longDateFormat[format];
+		} else {
+			return format;			
+		}
+	},
+
 	calculateState: function( props ) {
 		var date = props.selectedDate || props.viewDate,
-			format = props.timeFormat,
+			format = this.getLocalizedFormat(props.timeFormat),
 			counters = []
 			;
 
@@ -30,8 +40,8 @@ var DateTimePickerTime = onClickOutside( createClass({
 		var hours = date.format( 'H' );
 		
 		var daypart = false;
-		if ( this.state !== null && this.props.timeFormat.toLowerCase().indexOf( ' a' ) !== -1 ) {
-			if ( this.props.timeFormat.indexOf( ' A' ) !== -1 ) {
+		if ( this.state !== null && format.toLowerCase().indexOf( ' a' ) !== -1 ) {
+			if ( format.indexOf( ' A' ) !== -1 ) {
 				daypart = ( hours >= 12 ) ? 'PM' : 'AM';
 			} else {
 				daypart = ( hours >= 12 ) ? 'pm' : 'am';
@@ -51,7 +61,7 @@ var DateTimePickerTime = onClickOutside( createClass({
 	renderCounter: function( type ) {
 		if ( type !== 'daypart' ) {
 			var value = this.state[ type ];
-			if ( type === 'hours' && this.props.timeFormat.toLowerCase().indexOf( ' a' ) !== -1 ) {
+			if ( type === 'hours' && this.getLocalizedFormat(this.props.timeFormat).toLowerCase().indexOf( ' a' ) !== -1 ) {
 				value = ( value - 1 ) % 12 + 1;
 
 				if ( value === 0 ) {
@@ -77,8 +87,9 @@ var DateTimePickerTime = onClickOutside( createClass({
 
 	render: function() {
 		var me = this,
+			format = this.getLocalizedFormat(this.props.timeFormat),
 			counters = []
-		;
+			;
 
 		this.state.counters.forEach( function( c ) {
 			if ( counters.length )
@@ -90,7 +101,7 @@ var DateTimePickerTime = onClickOutside( createClass({
 			counters.push( me.renderDayPart() );
 		}
 
-		if ( this.state.counters.length === 3 && this.props.timeFormat.indexOf( 'S' ) !== -1 ) {
+		if ( this.state.counters.length === 3 && format.indexOf( 'S' ) !== -1 ) {
 			counters.push( React.createElement('div', { className: 'rdtCounterSeparator', key: 'sep5' }, ':' ) );
 			counters.push(
 				React.createElement('div', { className: 'rdtCounter rdtMilli', key: 'm' },


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the *Title* above -->

### Description
<!-- Describe your changes in detail -->
Added method `getLocalizedFormat` in `TimeView.js` and utilized it there so as to allow proper handling of locale-aware moment.js time formats like LT/LTS.

### Motivation and Context
<!--
  * Why do you think this pull request should be merged?
  * Does it solve a problem, in that case what problem?
  * If these changes fixes an open issue, please provide a link to the issue here
-->
Users of the library will often want to input locale-aware `timeFormat` props, which are supported by moment.js. As the issue #431 explains, this is a requested feature and implemented here.

### Checklist
<!--
  The purpose of this checklist is for you to not forget changes you most likely should do. Look 
  through the following points, and put an "x" in all the boxes that apply. If you're unsure about 
  any of these points, then we'd recommend you to read the README. If something still is unclear 
  then don't hesitate to ask. We're here to help!
-->
```
[x] I have not included any built dist files (us maintainers do that prior to a new release)
[ ] I have added tests covering my changes
[ ] All new and existing tests pass
[x] My changes required the documentation to be updated
  [ ] I have updated the documentation accordingly
  [ ] I have updated the TypeScript 1.8 type definitions accordingly
  [ ] I have updated the TypeScript 2.0+ type definitions accordingly
```


<!--
  Is there anything in this template you think is confusing, unclear, redundant or just simply bad?
  Please let us know either via creating an issue or creating a PR with changes to it.
-->

### Note
There are two tests failing in the master branch, but this commit does not seem to affect them.