### PR TITLE
Create disableEventPropagation prop to avoid external event side-effects

### DIFF
--- a/DateTime.js
+++ b/DateTime.js
@@ -15,6 +15,13 @@ var viewModes = Object.freeze({
 	TIME: 'time',
 });
 
+var stopEventPropagation = function ( e ) { e.nativeEvent.stopImmediatePropagation(); };
+var eventPropagationHandlers = Object.freeze({
+	onClick: stopEventPropagation,
+	onKeyUp: stopEventPropagation,
+	onTouchEnd: stopEventPropagation
+});
+
 var TYPES = PropTypes;
 var Datetime = createClass({
 	displayName: 'DateTime',
@@ -40,7 +47,8 @@ var Datetime = createClass({
 		open: TYPES.bool,
 		strictParsing: TYPES.bool,
 		closeOnSelect: TYPES.bool,
-		closeOnTab: TYPES.bool
+		closeOnTab: TYPES.bool,
+		disableEventPropagation: TYPES.bool
 	},
 
 	getInitialState: function() {
@@ -446,7 +454,12 @@ var Datetime = createClass({
 		if ( this.state.open )
 			className += ' rdtOpen';
 
-		return React.createElement( 'div', { className: className }, children.concat(
+		var rootProps = Object.assign(
+			{ className: className },
+			this.props.disableEventPropagation ? eventPropagationHandlers : null
+		);
+
+		return React.createElement( 'div', rootProps, children.concat(
 			React.createElement( 'div',
 				{ key: 'dt', className: 'rdtPicker' },
 				React.createElement( CalendarContainer, { view: this.state.currentView, viewProps: this.getComponentProps(), onClickOutside: this.handleClickOutside })
@@ -458,6 +471,7 @@ var Datetime = createClass({
 Datetime.defaultProps = {
 	className: '',
 	defaultValue: '',
+	disableEventPropagation: false,
 	inputProps: {},
 	input: true,
 	onFocus: function() {},

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ render: function() {
 | **closeOnTab** | `boolean` | `true` | When `true` and the input is focused, pressing the `tab` key will close the datepicker.
 | **timeConstraints** | `object` | `null` | Add some constraints to the timepicker. It accepts an `object` with the format `{ hours: { min: 9, max: 15, step: 2 }}`, this example means the hours can't be lower than `9` and higher than `15`, and it will change adding or subtracting `2` hours everytime the buttons are clicked. The constraints can be added to the `hours`, `minutes`, `seconds` and `milliseconds`.
 | **disableOnClickOutside** | `boolean` | `false` | When `true`, keep the datepicker open when click event is triggered outside of component. When `false`, close it.
+| **disableEventPropagation** | `boolean` | `false` | When `true`, all synthetic click/touch/key events will stop native event propagation at the bounds of this component.
 
 ## i18n
 Different language and date formats are supported by react-datetime. React uses [Moment.js](http://momentjs.com/) to format the dates, and the easiest way of changing the language of the calendar is [changing the Moment.js locale](http://momentjs.com/docs/#/i18n/changing-locale/).

--- a/test/testUtils.js
+++ b/test/testUtils.js
@@ -13,7 +13,7 @@ const _simulateClickOnElement = (element) => {
 
 module.exports = {
 	createDatetime: (props) => {
-		return mount(<Datetime {...props} />);
+		return mount(<Datetime {...props} disableEventPropagation={true} />);
 	},
 
 	createDatetimeShallow: (props) => {

--- a/test/testUtils.js
+++ b/test/testUtils.js
@@ -8,7 +8,7 @@ const _simulateClickOnElement = (element) => {
 		console.warn('Element not clicked since it doesn\'t exist');
 		return;
 	}
-	return element.simulate('click');
+	return element.simulate('click', { nativeEvent: { stopImmediatePropagation: () => {} } });
 };
 
 module.exports = {

--- a/test/tests.spec.js
+++ b/test/tests.spec.js
@@ -215,7 +215,7 @@ describe('Datetime', () => {
 	it('opens picker when clicking on input', () => {
 		const component = utils.createDatetime();
 		expect(utils.isOpen(component)).toBeFalsy();
-		component.find('.form-control').simulate('click');
+		component.find('.form-control').simulate('click', { nativeEvent: { stopImmediatePropagation: () => {} } });
 		expect(utils.isOpen(component)).toBeTruthy();
 	});
 


### PR DESCRIPTION
### Description
We wrap react-datetime in a Semantic UI modal, and sometimes (particularly the TimeView clicks) react-datetime click propagation would cause our modals to behave irregularly.

This should allow users of react-datetime to bound events to this component, and avoid them creating external side-effects in the client application.

### Motivation and Context
Explained above.

### Checklist
```
[x] I have not included any built dist files (us maintainers do that prior to a new release)
[x] I have added tests covering my changes
[x] All new and existing tests pass
[x] My changes required the documentation to be updated
  [x] I have updated the documentation accordingly
  [x] I have updated the TypeScript 1.8 type definitions accordingly
  [x] I have updated the TypeScript 2.0+ type definitions accordingly
```