### PR TITLE
Fix infinity setState when holding multiple buttons down

### DIFF
--- a/src/TimeView.js
+++ b/src/TimeView.js
@@ -170,6 +170,7 @@ var DateTimePickerTime = onClickOutside( createClass({
 			me.setState( update );
 
 			me.timer = setTimeout( function() {
+				clearInterval( me.increaseTimer );
 				me.increaseTimer = setInterval( function() {
 					update[ type ] = me[ action ]( type );
 					me.setState( update );


### PR DESCRIPTION
### Description
Clearing interval before create

### Motivation and Context

Scenario: On time picker arrows - right mouse down, left mouse down, both mouse up
Expecting: Time counter stops to increase
Actual: Time counter increasing even after both mouse up

### Checklist
```
[x] I have not included any built dist files (us maintainers do that prior to a new release)
[ ] I have added tests covering my changes
[x] All new and existing tests pass
[ ] My changes required the documentation to be updated
  [ ] I have updated the documentation accordingly
  [ ] I have updated the TypeScript 1.8 type definitions accordingly
  [ ] I have updated the TypeScript 2.0+ type definitions accordingly
```