### PR TITLE
Allow strictParsing when setting displayTimeZone

### DIFF
--- a/DateTime.js
+++ b/DateTime.js
@@ -396,7 +396,7 @@ var Datetime = createClass({
 		if (props.utc) {
 			m = moment.utc(date, format, props.strictParsing);
 		} else if (props.displayTimeZone) {
-			m = moment.tz(date, format, props.displayTimeZone);
+			m = moment.tz(date, format, props.strictParsing, props.displayTimeZone);
 		} else {
 			m = moment(date, format, props.strictParsing);
 		}


### PR DESCRIPTION
### Description
Currently, when setting `displayTimeZone` strict parsing will not work because `props.strictParsing` is not being passed to `moment.tz`. `moment.tz` is able to accept a boolean to enable/disable strict parsing [according to the docs](https://momentjs.com/timezone/docs/#/using-timezones/parsing-in-zone/).

### Motivation and Context
See above
