### PR TITLE
Add ability to customize first day of week

### DIFF
--- a/DateTime.d.ts
+++ b/DateTime.d.ts
@@ -170,6 +170,10 @@ declare namespace ReactDatetimeClass {
          close it.
          */
         disableOnClickOutside?: boolean;
+        /*
+         Customize the first day of the week in the date picker (`monday`, `tuesday`, `wednesday`, `thursday`, `friday`, `saturday`, `sunday`).
+         */
+        firstDayOfWeek?: string;
     }
 
     export interface DatetimepickerState {

--- a/DateTime.js
+++ b/DateTime.js
@@ -42,7 +42,8 @@ var Datetime = createClass({
 		open: TYPES.bool,
 		strictParsing: TYPES.bool,
 		closeOnSelect: TYPES.bool,
-		closeOnTab: TYPES.bool
+		closeOnTab: TYPES.bool,
+		firstDayOfWeek: TYPES.string
 	},
 
 	getInitialState: function() {
@@ -416,7 +417,7 @@ var Datetime = createClass({
 	},
 
 	componentProps: {
-		fromProps: ['value', 'isValidDate', 'renderDay', 'renderMonth', 'renderYear', 'timeConstraints'],
+		fromProps: ['value', 'isValidDate', 'renderDay', 'renderMonth', 'renderYear', 'timeConstraints', 'firstDayOfWeek'],
 		fromState: ['viewDate', 'selectedDate', 'updateOn'],
 		fromThis: ['setDate', 'setTime', 'showView', 'addTime', 'subtractTime', 'updateSelectedDate', 'localMoment', 'handleClickOutside']
 	},

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ render: function() {
 | **closeOnTab** | `boolean` | `true` | When `true` and the input is focused, pressing the `tab` key will close the datepicker.
 | **timeConstraints** | `object` | `null` | Add some constraints to the timepicker. It accepts an `object` with the format `{ hours: { min: 9, max: 15, step: 2 }}`, this example means the hours can't be lower than `9` and higher than `15`, and it will change adding or subtracting `2` hours everytime the buttons are clicked. The constraints can be added to the `hours`, `minutes`, `seconds` and `milliseconds`.
 | **disableCloseOnClickOutside** | `boolean` | `false` | When `true`, keep the datepicker open when click event is triggered outside of component. When `false`, close it.
+| **firstDayOfWeek** | `string` | `null` | Customize the first day of the week in the date picker (`monday`, `tuesday`, `wednesday`, `thursday`, `friday`, `saturday`, `sunday`).
 
 ## i18n
 Different language and date formats are supported by react-datetime. React uses [Moment.js](http://momentjs.com/) to format the dates, and the easiest way of changing the language of the calendar is [changing the Moment.js locale](http://momentjs.com/docs/#/i18n/changing-locale/).

--- a/react-datetime.d.ts
+++ b/react-datetime.d.ts
@@ -157,6 +157,10 @@ declare module ReactDatetime {
      close it.
     */
     disableOnClickOutside?: boolean;
+    /*
+     Customize the first day of the week in the date picker (`monday`, `tuesday`, `wednesday`, `thursday`, `friday`, `saturday`, `sunday`).
+     */
+    firstDayOfWeek?: string;
   }
 
   interface DatetimeComponent extends React.ComponentClass<DatetimepickerProps> {

--- a/src/DaysView.js
+++ b/src/DaysView.js
@@ -45,6 +45,10 @@ var DateTimePickerDays = createClass({
 			i = 0
 			;
 
+		if (this.props.firstDayOfWeek) {
+			first = moment().day(this.props.firstDayOfWeek).day();
+		}
+
 		days.forEach( function( day ) {
 			dow[ (7 + ( i++ ) - first) % 7 ] = day;
 		});
@@ -67,6 +71,10 @@ var DateTimePickerDays = createClass({
 
 		// Go to the last week of the previous month
 		prevMonth.date( prevMonth.daysInMonth() ).startOf( 'week' );
+		if (this.props.firstDayOfWeek) {
+			prevMonth.day(this.props.firstDayOfWeek);
+		}
+
 		var lastDay = prevMonth.clone().add( 42, 'd' );
 
 		while ( prevMonth.isBefore( lastDay ) ) {

--- a/test/tests.spec.js
+++ b/test/tests.spec.js
@@ -766,7 +766,7 @@ describe('Datetime', () => {
 			expect(utils.getNthDay(component, 0).hasClass('rdtOld')).toBeTruthy();
 			expect(utils.getNthDay(component, 41).text()).toEqual('6');
 			expect(utils.getNthDay(component, 41).hasClass('rdtNew')).toBeTruthy();
-			expect(component.find('.rdtDays .dow').at(0).text()).toEqual('Mo')
+			expect(component.find('.rdtDays .dow').at(0).text()).toEqual('Mo');
 		});
 
 		it('firstDayOfWeek=thursday', () => {
@@ -776,7 +776,7 @@ describe('Datetime', () => {
 			expect(utils.getNthDay(component, 0).hasClass('rdtOld')).toBeTruthy();
 			expect(utils.getNthDay(component, 41).text()).toEqual('9');
 			expect(utils.getNthDay(component, 41).hasClass('rdtNew')).toBeTruthy();
-			expect(component.find('.rdtDays .dow').at(0).text()).toEqual('Th')
+			expect(component.find('.rdtDays .dow').at(0).text()).toEqual('Th');
 		});
 
 		describe('defaultValue of type', () => {

--- a/test/tests.spec.js
+++ b/test/tests.spec.js
@@ -759,6 +759,26 @@ describe('Datetime', () => {
 			}, 0);
 		});
 
+		it('firstDayOfWeek=monday', () => {
+			const date = new Date(2000, 0, 15, 2, 2, 2, 2),
+			component = utils.createDatetime({ value: date, firstDayOfWeek: 'monday' });
+			expect(utils.getNthDay(component, 0).text()).toEqual('27');
+			expect(utils.getNthDay(component, 0).hasClass('rdtOld')).toBeTruthy();
+			expect(utils.getNthDay(component, 41).text()).toEqual('6');
+			expect(utils.getNthDay(component, 41).hasClass('rdtNew')).toBeTruthy();
+			expect(component.find('.rdtDays .dow').at(0).text()).toEqual('Mo')
+		});
+
+		it('firstDayOfWeek=thursday', () => {
+			const date = new Date(2000, 0, 15, 2, 2, 2, 2),
+			component = utils.createDatetime({ value: date, firstDayOfWeek: 'thursday' });
+			expect(utils.getNthDay(component, 0).text()).toEqual('30');
+			expect(utils.getNthDay(component, 0).hasClass('rdtOld')).toBeTruthy();
+			expect(utils.getNthDay(component, 41).text()).toEqual('9');
+			expect(utils.getNthDay(component, 41).hasClass('rdtNew')).toBeTruthy();
+			expect(component.find('.rdtDays .dow').at(0).text()).toEqual('Th')
+		});
+
 		describe('defaultValue of type', () => {
 			it('date', () => {
 				const date = new Date(2000, 0, 15, 2, 2, 2, 2),


### PR DESCRIPTION
### Description
This allows you to customize the first day of the week in `react-datetime` by passing in the first day of the week as a string. 

```js
<Datetime firstDayOfWeek="sunday" />
```

### Motivation and Context
This is independent of locale. So if a users locale says the first day of the week is `Sunday`, but you would like to force it to be `Monday` in the datetime picker, this allows you to do so. In addition if you want to customize based on some setting, this allows you to do that as well. We are using something like this in our app so that the user can set their first day of the week in their profile settings and this is then reflected in a calendar view and also in the datetime pickers throughout the app.

### Checklist
<!--
  The purpose of this checklist is for you to not forget changes you most likely should do. Look 
  through the following points, and put an "x" in all the boxes that apply. If you're unsure about 
  any of these points, then we'd recommend you to read the README. If something still is unclear 
  then don't hesitate to ask. We're here to help!
-->
```
[x] I have not included any built dist files (us maintainers do that prior to a new release)
[x] I have added tests covering my changes
[x] All new and existing tests pass
[x] My changes required the documentation to be updated
  [x] I have updated the documentation accordingly
  [x] I have updated the TypeScript 1.8 type definitions accordingly
  [x] I have updated the TypeScript 2.0+ type definitions accordingly
```

@arqex this is the same as https://github.com/YouCanBookMe/react-datetime/pull/568 but with tests.