### PR TITLE
Fix not able to edit milliseconds field in the widget.

### DIFF
--- a/src/TimeView.js
+++ b/src/TimeView.js
@@ -144,7 +144,7 @@ var DateTimePickerTime = createClass({
 
 	updateMilli: function( e ) {
 		var milli = parseInt( e.target.value, 10 );
-		if ( milli === e.target.value && milli >= 0 && milli < 1000 ) {
+		if ( typeof milli === 'number' && milli >= 0 && milli < 1000 ) {
 			this.props.setTime( 'milliseconds', milli );
 			this.setState( { milliseconds: milli } );
 		}


### PR DESCRIPTION
Currently, it's not able to edit milliseconds field in widget.
That's because the assertion of milliseconds is incorrect.

### Motivation and Context
please refer this issue YouCanBookMe/react-datetime#485

### Checklist

- [x] I have not included any built dist files (us maintainers do that prior to a new release)
- [ ] I have added tests covering my changes
- [ ] All new and existing tests pass
- [ ] My changes required the documentation to be updated
  - [ ] I have updated the documentation accordingly
  - [ ] I have updated the TypeScript 1.8 type definitions accordingly
  - [ ] I have updated the TypeScript 2.0+ type definitions accordingly

