### PR TITLE
Modify time-picker to display additional zero before hours

### DIFF
--- a/DateTime.d.ts
+++ b/DateTime.d.ts
@@ -170,6 +170,10 @@ declare namespace ReactDatetimeClass {
          close it.
          */
         disableOnClickOutside?: boolean;
+        /*
+         When true, add zero to hours from 0 to 9.
+         */
+        militaryTime?: boolean;
     }
 
     export interface DatetimepickerState {

--- a/DateTime.js
+++ b/DateTime.js
@@ -42,7 +42,8 @@ var Datetime = createClass({
 		open: TYPES.bool,
 		strictParsing: TYPES.bool,
 		closeOnSelect: TYPES.bool,
-		closeOnTab: TYPES.bool
+		closeOnTab: TYPES.bool,
+        militaryTime: TYPES.bool
 	},
 
 	getInitialState: function() {
@@ -416,7 +417,7 @@ var Datetime = createClass({
 	},
 
 	componentProps: {
-		fromProps: ['value', 'isValidDate', 'renderDay', 'renderMonth', 'renderYear', 'timeConstraints'],
+		fromProps: ['value', 'isValidDate', 'renderDay', 'renderMonth', 'renderYear', 'timeConstraints', 'militaryTime'],
 		fromState: ['viewDate', 'selectedDate', 'updateOn'],
 		fromThis: ['setDate', 'setTime', 'showView', 'addTime', 'subtractTime', 'updateSelectedDate', 'localMoment', 'handleClickOutside']
 	},
@@ -528,7 +529,8 @@ Datetime.defaultProps = {
 	strictParsing: true,
 	closeOnSelect: false,
 	closeOnTab: true,
-	utc: false
+	utc: false,
+	militaryTime: false
 };
 
 // Make moment accessible through the Datetime class

--- a/DateTime.js
+++ b/DateTime.js
@@ -43,7 +43,7 @@ var Datetime = createClass({
 		strictParsing: TYPES.bool,
 		closeOnSelect: TYPES.bool,
 		closeOnTab: TYPES.bool,
-        militaryTime: TYPES.bool
+		militaryTime: TYPES.bool
 	},
 
 	getInitialState: function() {

--- a/react-datetime.d.ts
+++ b/react-datetime.d.ts
@@ -157,6 +157,10 @@ declare module ReactDatetime {
      close it.
     */
     disableOnClickOutside?: boolean;
+    /*
+     When true, add zero to hours from 0 to 9.
+     */
+    militaryTime?: boolean;
   }
 
   interface DatetimeComponent extends React.ComponentClass<DatetimepickerProps> {

--- a/src/TimeView.js
+++ b/src/TimeView.js
@@ -134,11 +134,11 @@ var DateTimePickerTime = createClass({
 			}
 		};
 		me.padValues = {
-            hours: this.props.militaryTime ? 2 : 1,
-            minutes: 2,
-            seconds: 2,
-            milliseconds: 3
-        };
+			hours: this.props.militaryTime ? 2 : 1,
+			minutes: 2,
+			seconds: 2,
+			milliseconds: 3
+		};
 		['hours', 'minutes', 'seconds', 'milliseconds'].forEach( function( type ) {
 			assign(me.timeConstraints[ type ], me.props.timeConstraints[ type ]);
 		});

--- a/src/TimeView.js
+++ b/src/TimeView.js
@@ -26,7 +26,7 @@ var DateTimePickerTime = createClass({
 			}
 		}
 
-		var hours = date.format( 'H' );
+		var hours = date.format( this.props.militaryTime ? 'HH' : 'H' );
 
 		var daypart = false;
 		if ( this.state !== null && this.props.timeFormat.toLowerCase().indexOf( ' a' ) !== -1 ) {
@@ -56,6 +56,7 @@ var DateTimePickerTime = createClass({
 				if ( value === 0 ) {
 					value = 12;
 				}
+				value = this.pad( type, value );
 			}
 			return React.createElement('div', { key: type, className: 'rdtCounter' }, [
 				React.createElement('span', { key: 'up', className: 'rdtBtn', onMouseDown: this.onStartClicking( 'increase', type ), onContextMenu: this.disableContextMenu }, '▲' ),
@@ -132,6 +133,12 @@ var DateTimePickerTime = createClass({
 				step: 1
 			}
 		};
+		me.padValues = {
+            hours: this.props.militaryTime ? 2 : 1,
+            minutes: 2,
+            seconds: 2,
+            milliseconds: 3
+        };
 		['hours', 'minutes', 'seconds', 'milliseconds'].forEach( function( type ) {
 			assign(me.timeConstraints[ type ], me.props.timeConstraints[ type ]);
 		});
@@ -191,13 +198,6 @@ var DateTimePickerTime = createClass({
 	disableContextMenu: function( event ) {
 		event.preventDefault();
 		return false;
-	},
-
-	padValues: {
-		hours: 1,
-		minutes: 2,
-		seconds: 2,
-		milliseconds: 3
 	},
 
 	toggleDayPart: function( type ) { // type is always 'hours'


### PR DESCRIPTION
Modify time-picker to display additional zero before hours. This should apply only for numbers from 0 to 9.

### Motivation and Context:
We can format date in text field in different ways, let's see an example:
09/17/2019 **03**:28 AM
So it would be great to add additional '0' to hours in time-picker.

### Checklist
[x ] I have not included any built dist files (us maintainers do that prior to a new release)
[ ] I have added tests covering my changes
[ ] All new and existing tests pass
[x ] My changes required the documentation to be updated
  [ ] I have updated the documentation accordingly
  [ ] I have updated the TypeScript 1.8 type definitions accordingly
  [ ] I have updated the TypeScript 2.0+ type definitions accordingly
