### PR TITLE
Added closeOnTab on type definitions

### DIFF
--- a/DateTime.d.ts
+++ b/DateTime.d.ts
@@ -159,6 +159,11 @@ declare namespace ReactDatetimeClass {
          */
         closeOnSelect?: boolean;
         /*
+        /*
+        When true and the input is focused, pressing the tab key will close the datepicker.
+         */
+        closeOnTab?: boolean;
+        /*
          Allow to add some constraints to the time selector. It accepts an object with the format
          {hours:{ min: 9, max: 15, step:2}} so the hours can't be lower than 9 or higher than 15, and
          it will change adding or subtracting 2 hours everytime the buttons are clicked. The constraints

--- a/DateTime.d.ts
+++ b/DateTime.d.ts
@@ -159,8 +159,7 @@ declare namespace ReactDatetimeClass {
          */
         closeOnSelect?: boolean;
         /*
-        /*
-        When true and the input is focused, pressing the tab key will close the datepicker.
+         When true and the input is focused, pressing the tab key will close the datepicker.
          */
         closeOnTab?: boolean;
         /*


### PR DESCRIPTION
[-] I have not included any built dist files (us maintainers do that prior to a new release)
[] I have added tests covering my changes
[] All new and existing tests pass
[ ] My changes required the documentation to be updated
  [ ] I have updated the documentation accordingly
  [ ] I have updated the TypeScript 1.8 type definitions accordingly
  [-] I have updated the TypeScript 2.0+ type definitions accordingly
```


<!--
  Is there anything in this template you think is confusing, unclear, redundant or just simply bad?
  Please let us know either via creating an issue or creating a PR with changes to it.
-->
