### PR TITLE
Convert components to ES2015 classes

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,6 +6,9 @@ module.exports = {
         "require": true,
         "module": true
     },
+    "parserOptions": {
+        "ecmaVersion": 2015
+    },
     // Enables rules that report common problems,
     // see http://eslint.org/docs/rules/ for list
     "extends": "eslint:recommended",

--- a/DateTime.js
+++ b/DateTime.js
@@ -2,7 +2,6 @@
 
 var assign = require('object-assign'),
 	PropTypes = require('prop-types'),
-	createClass = require('create-react-class'),
 	moment = require('moment'),
 	React = require('react'),
 	CalendarContainer = require('./src/CalendarContainer'),
@@ -17,49 +16,50 @@ var viewModes = Object.freeze({
 });
 
 var TYPES = PropTypes;
-var Datetime = createClass({
-	displayName: 'DateTime',
-	propTypes: {
-		// value: TYPES.object | TYPES.string,
-		// defaultValue: TYPES.object | TYPES.string,
-		// viewDate: TYPES.object | TYPES.string,
-		onFocus: TYPES.func,
-		onBlur: TYPES.func,
-		onChange: TYPES.func,
-		onViewModeChange: TYPES.func,
-		onNavigateBack: TYPES.func,
-		onNavigateForward: TYPES.func,
-		locale: TYPES.string,
-		utc: TYPES.bool,
-		displayTimeZone: TYPES.string,
-		input: TYPES.bool,
-		// dateFormat: TYPES.string | TYPES.bool,
-		// timeFormat: TYPES.string | TYPES.bool,
-		inputProps: TYPES.object,
-		timeConstraints: TYPES.object,
-		viewMode: TYPES.oneOf([viewModes.YEARS, viewModes.MONTHS, viewModes.DAYS, viewModes.TIME]),
-		isValidDate: TYPES.func,
-		open: TYPES.bool,
-		strictParsing: TYPES.bool,
-		closeOnSelect: TYPES.bool,
-		closeOnTab: TYPES.bool
-	},
 
-	getInitialState: function() {
+class Datetime extends React.Component {
+	constructor(props) {
+		super(props);
+		this.displayName = 'DateTime';
+		this.parseDate = this.parseDate.bind(this);
+		this.getStateFromProps = this.getStateFromProps.bind(this);
+		this.getUpdateOn = this.getUpdateOn.bind(this);
+		this.getFormats = this.getFormats.bind(this);
+		this.onInputChange = this.onInputChange.bind(this);
+		this.onInputKey = this.onInputKey.bind(this);
+		this.showView = this.showView.bind(this);
+		this.setDate = this.setDate.bind(this);
+		this.subtractTime = this.subtractTime.bind(this);
+		this.addTime = this.addTime.bind(this);
+		this.updateTime = this.updateTime.bind(this);
+		this.allowedSetTime = ['hours', 'minutes', 'seconds', 'milliseconds'];
+		this.setTime = this.setTime.bind(this);
+		this.updateSelectedDate = this.updateSelectedDate.bind(this);
+		this.openCalendar = this.openCalendar.bind(this);
+		this.closeCalendar = this.closeCalendar.bind(this);
+		this.handleClickOutside = this.handleClickOutside.bind(this);
+		this.localMoment = this.localMoment.bind(this);
+		this.checkTZ = this.checkTZ.bind(this);
+		this.componentProps = {
+			fromProps: ['value', 'isValidDate', 'renderDay', 'renderMonth', 'renderYear', 'timeConstraints'],
+			fromState: ['viewDate', 'selectedDate', 'updateOn'],
+			fromThis: ['setDate', 'setTime', 'showView', 'addTime', 'subtractTime', 'updateSelectedDate', 'localMoment', 'handleClickOutside']
+		};
+		this.getComponentProps = this.getComponentProps.bind(this);
+		this.overrideEvent = this.overrideEvent.bind(this);
+
 		this.checkTZ( this.props );
 		
-		var state = this.getStateFromProps( this.props );
+		this.state = this.getStateFromProps( this.props );
 
-		if ( state.open === undefined )
-			state.open = !this.props.input;
+		if ( this.state.open === undefined )
+			this.state.open = !this.props.input;
 
-		state.currentView = this.props.dateFormat ?
-			(this.props.viewMode || state.updateOn || viewModes.DAYS) : viewModes.TIME;
+		this.state.currentView = this.props.dateFormat ?
+			(this.props.viewMode || this.state.updateOn || viewModes.DAYS) : viewModes.TIME;
+	}
 
-		return state;
-	},
-
-	parseDate: function (date, formats) {
+	parseDate(date, formats) {
 		var parsedDate;
 
 		if (date && typeof date === 'string')
@@ -71,9 +71,9 @@ var Datetime = createClass({
 			parsedDate = null;
 
 		return parsedDate;
-	},
+	}
 
-	getStateFromProps: function( props ) {
+	getStateFromProps( props ) {
 		var formats = this.getFormats( props ),
 			date = props.value || props.defaultValue,
 			selectedDate, viewDate, updateOn, inputValue
@@ -104,9 +104,9 @@ var Datetime = createClass({
 			inputValue: inputValue,
 			open: props.open
 		};
-	},
+	}
 
-	getUpdateOn: function( formats ) {
+	getUpdateOn( formats ) {
 		if ( formats.date.match(/[lLD]/) ) {
 			return viewModes.DAYS;
 		} else if ( formats.date.indexOf('M') !== -1 ) {
@@ -116,9 +116,9 @@ var Datetime = createClass({
 		}
 
 		return viewModes.DAYS;
-	},
+	}
 
-	getFormats: function( props ) {
+	getFormats( props ) {
 		var formats = {
 				date: props.dateFormat || '',
 				time: props.timeFormat || ''
@@ -143,9 +143,9 @@ var Datetime = createClass({
 		;
 
 		return formats;
-	},
+	}
 
-	componentWillReceiveProps: function( nextProps ) {
+	componentWillReceiveProps( nextProps ) {
 		var formats = this.getFormats( nextProps ),
 			updatedState = {}
 		;
@@ -213,9 +213,9 @@ var Datetime = createClass({
 		this.checkTZ( nextProps );
 
 		this.setState( updatedState );
-	},
+	}
 
-	onInputChange: function( e ) {
+	onInputChange( e ) {
 		var value = e.target === null ? e : e.target.value,
 			localMoment = this.localMoment( value, this.state.inputFormat ),
 			update = { inputValue: value }
@@ -231,23 +231,23 @@ var Datetime = createClass({
 		return this.setState( update, function() {
 			return this.props.onChange( localMoment.isValid() ? localMoment : this.state.inputValue );
 		});
-	},
+	}
 
-	onInputKey: function( e ) {
+	onInputKey( e ) {
 		if ( e.which === 9 && this.props.closeOnTab ) {
 			this.closeCalendar();
 		}
-	},
+	}
 
-	showView: function( view ) {
+	showView( view ) {
 		var me = this;
 		return function() {
 			me.state.currentView !== view && me.props.onViewModeChange( view );
 			me.setState({ currentView: view });
 		};
-	},
+	}
 
-	setDate: function( type ) {
+	setDate( type ) {
 		var me = this,
 			nextViews = {
 				month: viewModes.DAYS,
@@ -261,35 +261,34 @@ var Datetime = createClass({
 			});
 			me.props.onViewModeChange( nextViews[ type ] );
 		};
-	},
+	}
 
-	subtractTime: function( amount, type, toSelected ) {
+	subtractTime( amount, type, toSelected ) {
 		var me = this;
 		return function() {
 			me.props.onNavigateBack( amount, type );
 			me.updateTime( 'subtract', amount, type, toSelected );
 		};
-	},
+	}
 
-	addTime: function( amount, type, toSelected ) {
+	addTime( amount, type, toSelected ) {
 		var me = this;
 		return function() {
 			me.props.onNavigateForward( amount, type );
 			me.updateTime( 'add', amount, type, toSelected );
 		};
-	},
+	}
 
-	updateTime: function( op, amount, type, toSelected ) {
+	updateTime( op, amount, type, toSelected ) {
 		var update = {},
 			date = toSelected ? 'selectedDate' : 'viewDate';
 
 		update[ date ] = this.state[ date ].clone()[ op ]( amount, type );
 
 		this.setState( update );
-	},
+	}
 
-	allowedSetTime: ['hours', 'minutes', 'seconds', 'milliseconds'],
-	setTime: function( type, value ) {
+	setTime( type, value ) {
 		var index = this.allowedSetTime.indexOf( type ) + 1,
 			state = this.state,
 			date = (state.selectedDate || state.viewDate).clone(),
@@ -311,9 +310,9 @@ var Datetime = createClass({
 			});
 		}
 		this.props.onChange( date );
-	},
+	}
 
-	updateSelectedDate: function( e, close ) {
+	updateSelectedDate( e, close ) {
 		var target = e.currentTarget,
 			modifier = 0,
 			viewDate = this.state.viewDate,
@@ -365,31 +364,31 @@ var Datetime = createClass({
 		}
 
 		this.props.onChange( date );
-	},
+	}
 
-	openCalendar: function( e ) {
+	openCalendar( e ) {
 		if ( !this.state.open ) {
 			this.setState({ open: true }, function() {
 				this.props.onFocus( e );
 			});
 		}
-	},
+	}
 
-	closeCalendar: function() {
+	closeCalendar() {
 		this.setState({ open: false }, function () {
 			this.props.onBlur( this.state.selectedDate || this.state.inputValue );
 		});
-	},
+	}
 
-	handleClickOutside: function() {
+	handleClickOutside() {
 		if ( this.props.input && this.state.open && this.props.open === undefined && !this.props.disableCloseOnClickOutside ) {
 			this.setState({ open: false }, function() {
 				this.props.onBlur( this.state.selectedDate || this.state.inputValue );
 			});
 		}
-	},
+	}
 
-	localMoment: function( date, format, props ) {
+	localMoment( date, format, props ) {
 		props = props || this.props;
 		var m = null;
 
@@ -404,24 +403,18 @@ var Datetime = createClass({
 		if ( props.locale )
 			m.locale( props.locale );
 		return m;
-	},
+	}
 
-	checkTZ: function( props ) {
+	checkTZ( props ) {
 		var con = console;
 
 		if ( props.displayTimeZone && !this.tzWarning && !moment.tz ) {
 			this.tzWarning = true;
 			con && con.error('react-datetime: displayTimeZone prop with value "' + props.displayTimeZone +  '" is used but moment.js timezone is not loaded.');
 		}
-	},
+	}
 
-	componentProps: {
-		fromProps: ['value', 'isValidDate', 'renderDay', 'renderMonth', 'renderYear', 'timeConstraints'],
-		fromState: ['viewDate', 'selectedDate', 'updateOn'],
-		fromThis: ['setDate', 'setTime', 'showView', 'addTime', 'subtractTime', 'updateSelectedDate', 'localMoment', 'handleClickOutside']
-	},
-
-	getComponentProps: function() {
+	getComponentProps() {
 		var me = this,
 			formats = this.getFormats( this.props ),
 			props = {dateFormat: formats.date, timeFormat: formats.time}
@@ -438,9 +431,9 @@ var Datetime = createClass({
 		});
 
 		return props;
-	},
+	}
 
-	overrideEvent: function( handler, action ) {
+	overrideEvent( handler, action ) {
 		if ( !this.overridenEvents ) {
 			this.overridenEvents = {};
 		}
@@ -459,9 +452,9 @@ var Datetime = createClass({
 		}
 
 		return this.overridenEvents[handler];
-	},
+	}
 
-	render: function() {
+	render() {
 		// TODO: Make a function or clean up this code,
 		// logic right now is really hard to follow
 		var className = 'rdt' + (this.props.className ?
@@ -500,16 +493,45 @@ var Datetime = createClass({
 			)
 		));
 	}
-});
+}
+Datetime.propTypes = {
+	// value: TYPES.object | TYPES.string,
+	// defaultValue: TYPES.object | TYPES.string,
+	// viewDate: TYPES.object | TYPES.string,
+	onFocus: TYPES.func,
+	onBlur: TYPES.func,
+	onChange: TYPES.func,
+	onViewModeChange: TYPES.func,
+	onNavigateBack: TYPES.func,
+	onNavigateForward: TYPES.func,
+	locale: TYPES.string,
+	utc: TYPES.bool,
+	displayTimeZone: TYPES.string,
+	input: TYPES.bool,
+	// dateFormat: TYPES.string | TYPES.bool,
+	// timeFormat: TYPES.string | TYPES.bool,
+	inputProps: TYPES.object,
+	timeConstraints: TYPES.object,
+	viewMode: TYPES.oneOf([viewModes.YEARS, viewModes.MONTHS, viewModes.DAYS, viewModes.TIME]),
+	isValidDate: TYPES.func,
+	open: TYPES.bool,
+	strictParsing: TYPES.bool,
+	closeOnSelect: TYPES.bool,
+	closeOnTab: TYPES.bool
+};
 
-var ClickableWrapper = onClickOutside( createClass({
-	render: function() {
+var ClickableWrapper = onClickOutside(class extends React.Component {
+	constructor(props) {
+		super(props);
+		this.handleClickOutside = this.handleClickOutside.bind(this);
+	}
+	render() {
 		return React.createElement( 'div', { className: this.props.className }, this.props.children );
-	},
-	handleClickOutside: function( e ) {
+	}
+	handleClickOutside( e ) {
 		this.props.onClickOut( e );
 	}
-}));
+});
 
 Datetime.defaultProps = {
 	className: '',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1649,6 +1649,7 @@
       "version": "15.6.0",
       "resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.0.tgz",
       "integrity": "sha1-q0SEl8JlZuHilBPogyB9V8/nvtQ=",
+      "dev": true,
       "requires": {
         "fbjs": "^0.8.9",
         "loose-envify": "^1.3.1",
@@ -1658,7 +1659,8 @@
         "object-assign": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -80,7 +80,6 @@
     "webpack-stream": "^3.2.0"
   },
   "dependencies": {
-    "create-react-class": "^15.5.2",
     "object-assign": "^3.0.0",
     "prop-types": "^15.5.7",
     "react-onclickoutside": "^6.5.0"

--- a/src/CalendarContainer.js
+++ b/src/CalendarContainer.js
@@ -1,24 +1,26 @@
 'use strict';
 
 var React = require('react'),
-	createClass = require('create-react-class'),
 	DaysView = require('./DaysView'),
 	MonthsView = require('./MonthsView'),
 	YearsView = require('./YearsView'),
 	TimeView = require('./TimeView')
 	;
 
-var CalendarContainer = createClass({
-	viewComponents: {
-		days: DaysView,
-		months: MonthsView,
-		years: YearsView,
-		time: TimeView
-	},
+class CalendarContainer extends React.Component {
+	constructor(props) {
+		super(props);
+		this.viewComponents = {
+			days: DaysView,
+			months: MonthsView,
+			years: YearsView,
+			time: TimeView
+		};
+	}
 
-	render: function() {
+	render() {
 		return React.createElement( this.viewComponents[ this.props.view ], this.props.viewProps );
 	}
-});
+}
 
 module.exports = CalendarContainer;

--- a/src/DaysView.js
+++ b/src/DaysView.js
@@ -1,12 +1,21 @@
 'use strict';
 
 var React = require('react'),
-	createClass = require('create-react-class'),
 	moment = require('moment')
-	;
+;
 
-var DateTimePickerDays = createClass({
-	render: function() {
+class DateTimePickerDays extends React.Component {
+	constructor(props) {
+		super(props);
+		this.getDaysOfWeek = this.getDaysOfWeek.bind(this);
+		this.renderDays = this.renderDays.bind(this);
+		this.updateSelectedDate = this.updateSelectedDate.bind(this);
+		this.renderDay = this.renderDay.bind(this);
+		this.renderFooter = this.renderFooter.bind(this);
+		this.alwaysValidDate = this.alwaysValidDate.bind(this);
+	}
+
+	render() {
 		var footer = this.renderFooter(),
 			date = this.props.viewDate,
 			locale = date.localeData(),
@@ -31,14 +40,14 @@ var DateTimePickerDays = createClass({
 		return React.createElement('div', { className: 'rdtDays' },
 			React.createElement('table', {}, tableChildren )
 		);
-	},
+	}
 
 	/**
 	 * Get a list of the days of the week
 	 * depending on the current locale
 	 * @return {array} A list with the shortname of the days
 	 */
-	getDaysOfWeek: function( locale ) {
+	getDaysOfWeek( locale ) {
 		var days = locale._weekdaysMin,
 			first = locale.firstDayOfWeek(),
 			dow = [],
@@ -50,9 +59,9 @@ var DateTimePickerDays = createClass({
 		});
 
 		return dow;
-	},
+	}
 
-	renderDays: function() {
+	renderDays() {
 		var date = this.props.viewDate,
 			selected = this.props.selectedDate && this.props.selectedDate.clone(),
 			prevMonth = date.clone().subtract( 1, 'months' ),
@@ -108,17 +117,17 @@ var DateTimePickerDays = createClass({
 		}
 
 		return weeks;
-	},
+	}
 
-	updateSelectedDate: function( event ) {
+	updateSelectedDate( event ) {
 		this.props.updateSelectedDate( event, true );
-	},
+	}
 
-	renderDay: function( props, currentDate ) {
+	renderDay( props, currentDate ) {
 		return React.createElement('td',  props, currentDate.date() );
-	},
+	}
 
-	renderFooter: function() {
+	renderFooter() {
 		if ( !this.props.timeFormat )
 			return '';
 
@@ -129,11 +138,11 @@ var DateTimePickerDays = createClass({
 				React.createElement('td', { onClick: this.props.showView( 'time' ), colSpan: 7, className: 'rdtTimeToggle' }, date.format( this.props.timeFormat ))
 			)
 		);
-	},
+	}
 
-	alwaysValidDate: function() {
+	alwaysValidDate() {
 		return 1;
 	}
-});
+}
 
 module.exports = DateTimePickerDays;

--- a/src/MonthsView.js
+++ b/src/MonthsView.js
@@ -1,11 +1,17 @@
 'use strict';
 
-var React = require('react'),
-	createClass = require('create-react-class')
-;
+var React = require('react');
 
-var DateTimePickerMonths = createClass({
-	render: function() {
+class DateTimePickerMonths extends React.Component {
+	constructor(props) {
+		super(props);
+		this.renderMonths = this.renderMonths.bind(this);
+		this.updateSelectedMonth = this.updateSelectedMonth.bind(this);
+		this.renderMonth = this.renderMonth.bind(this);
+		this.alwaysValidDate = this.alwaysValidDate.bind(this);
+	}
+
+	render() {
 		return React.createElement('div', { className: 'rdtMonths' }, [
 			React.createElement('table', { key: 'a' }, React.createElement('thead', {}, React.createElement('tr', {}, [
 				React.createElement('th', { key: 'prev', className: 'rdtPrev', onClick: this.props.subtractTime( 1, 'years' )}, React.createElement('span', {}, '‹' )),
@@ -14,9 +20,9 @@ var DateTimePickerMonths = createClass({
 			]))),
 			React.createElement('table', { key: 'months' }, React.createElement('tbody', { key: 'b' }, this.renderMonths()))
 		]);
-	},
+	}
 
-	renderMonths: function() {
+	renderMonths() {
 		var date = this.props.selectedDate,
 			month = this.props.viewDate.month(),
 			year = this.props.viewDate.year(),
@@ -74,13 +80,13 @@ var DateTimePickerMonths = createClass({
 		}
 
 		return rows;
-	},
+	}
 
-	updateSelectedMonth: function( event ) {
+	updateSelectedMonth( event ) {
 		this.props.updateSelectedDate( event );
-	},
+	}
 
-	renderMonth: function( props, month ) {
+	renderMonth( props, month ) {
 		var localMoment = this.props.viewDate;
 		var monthStr = localMoment.localeData().monthsShort( localMoment.month( month ) );
 		var strLength = 3;
@@ -88,12 +94,12 @@ var DateTimePickerMonths = createClass({
 		// use a fixed string length for consistency
 		var monthStrFixedLength = monthStr.substring( 0, strLength );
 		return React.createElement('td', props, capitalize( monthStrFixedLength ) );
-	},
+	}
 
-	alwaysValidDate: function() {
+	alwaysValidDate() {
 		return 1;
-	},
-});
+	}
+}
 
 function capitalize( str ) {
 	return str.charAt( 0 ).toUpperCase() + str.slice( 1 );

--- a/src/TimeView.js
+++ b/src/TimeView.js
@@ -1,16 +1,34 @@
 'use strict';
 
 var React = require('react'),
-	createClass = require('create-react-class'),
 	assign = require('object-assign')
-	;
+;
 
-var DateTimePickerTime = createClass({
-	getInitialState: function() {
-		return this.calculateState( this.props );
-	},
+class DateTimePickerTime extends React.Component {
+	constructor(props) {
+		super(props);
+		this.calculateState = this.calculateState.bind(this);
+		this.renderCounter = this.renderCounter.bind(this);
+		this.renderDayPart = this.renderDayPart.bind(this);
+		this.updateMilli = this.updateMilli.bind(this);
+		this.renderHeader = this.renderHeader.bind(this);
+		this.onStartClicking = this.onStartClicking.bind(this);
+		this.disableContextMenu = this.disableContextMenu.bind(this);
+		this.padValues = {
+			hours: 1,
+			minutes: 2,
+			seconds: 2,
+			milliseconds: 3
+		};
+		this.toggleDayPart = this.toggleDayPart.bind(this);
+		this.increase = this.increase.bind(this);
+		this.decrease = this.decrease.bind(this);
+		this.pad = this.pad.bind(this);
 
-	calculateState: function( props ) {
+		this.state = this.calculateState( this.props );
+	}
+
+	calculateState( props ) {
 		var date = props.selectedDate || props.viewDate,
 			format = props.timeFormat,
 			counters = []
@@ -45,9 +63,9 @@ var DateTimePickerTime = createClass({
 			daypart: daypart,
 			counters: counters
 		};
-	},
+	}
 
-	renderCounter: function( type ) {
+	renderCounter( type ) {
 		if ( type !== 'daypart' ) {
 			var value = this.state[ type ];
 			if ( type === 'hours' && this.props.timeFormat.toLowerCase().indexOf( ' a' ) !== -1 ) {
@@ -64,17 +82,17 @@ var DateTimePickerTime = createClass({
 			]);
 		}
 		return '';
-	},
+	}
 
-	renderDayPart: function() {
+	renderDayPart() {
 		return React.createElement('div', { key: 'dayPart', className: 'rdtCounter' }, [
 			React.createElement('span', { key: 'up', className: 'rdtBtn', onMouseDown: this.onStartClicking( 'toggleDayPart', 'hours'), onContextMenu: this.disableContextMenu }, '▲' ),
 			React.createElement('div', { key: this.state.daypart, className: 'rdtCount' }, this.state.daypart ),
 			React.createElement('span', { key: 'do', className: 'rdtBtn', onMouseDown: this.onStartClicking( 'toggleDayPart', 'hours'), onContextMenu: this.disableContextMenu }, '▼' )
 		]);
-	},
+	}
 
-	render: function() {
+	render() {
 		var me = this,
 			counters = []
 		;
@@ -106,9 +124,9 @@ var DateTimePickerTime = createClass({
 				)))
 			])
 		);
-	},
+	}
 
-	componentWillMount: function() {
+	componentWillMount() {
 		var me = this;
 		me.timeConstraints = {
 			hours: {
@@ -136,21 +154,21 @@ var DateTimePickerTime = createClass({
 			assign(me.timeConstraints[ type ], me.props.timeConstraints[ type ]);
 		});
 		this.setState( this.calculateState( this.props ) );
-	},
+	}
 
-	componentWillReceiveProps: function( nextProps ) {
+	componentWillReceiveProps( nextProps ) {
 		this.setState( this.calculateState( nextProps ) );
-	},
+	}
 
-	updateMilli: function( e ) {
+	updateMilli( e ) {
 		var milli = parseInt( e.target.value, 10 );
 		if ( milli === e.target.value && milli >= 0 && milli < 1000 ) {
 			this.props.setTime( 'milliseconds', milli );
 			this.setState( { milliseconds: milli } );
 		}
-	},
+	}
 
-	renderHeader: function() {
+	renderHeader() {
 		if ( !this.props.dateFormat )
 			return null;
 
@@ -158,9 +176,9 @@ var DateTimePickerTime = createClass({
 		return React.createElement('thead', { key: 'h' }, React.createElement('tr', {},
 			React.createElement('th', { className: 'rdtSwitch', colSpan: 4, onClick: this.props.showView( 'days' ) }, date.format( this.props.dateFormat ) )
 		));
-	},
+	}
 
-	onStartClicking: function( action, type ) {
+	onStartClicking( action, type ) {
 		var me = this;
 
 		return function() {
@@ -186,47 +204,40 @@ var DateTimePickerTime = createClass({
 			document.body.addEventListener( 'mouseup', me.mouseUpListener );
 			document.body.addEventListener( 'touchend', me.mouseUpListener );
 		};
-	},
+	}
 
-	disableContextMenu: function( event ) {
+	disableContextMenu( event ) {
 		event.preventDefault();
 		return false;
-	},
+	}
 
-	padValues: {
-		hours: 1,
-		minutes: 2,
-		seconds: 2,
-		milliseconds: 3
-	},
-
-	toggleDayPart: function( type ) { // type is always 'hours'
+	toggleDayPart( type ) { // type is always 'hours'
 		var value = parseInt( this.state[ type ], 10) + 12;
 		if ( value > this.timeConstraints[ type ].max )
 			value = this.timeConstraints[ type ].min + ( value - ( this.timeConstraints[ type ].max + 1 ) );
 		return this.pad( type, value );
-	},
+	}
 
-	increase: function( type ) {
+	increase( type ) {
 		var value = parseInt( this.state[ type ], 10) + this.timeConstraints[ type ].step;
 		if ( value > this.timeConstraints[ type ].max )
 			value = this.timeConstraints[ type ].min + ( value - ( this.timeConstraints[ type ].max + 1 ) );
 		return this.pad( type, value );
-	},
+	}
 
-	decrease: function( type ) {
+	decrease( type ) {
 		var value = parseInt( this.state[ type ], 10) - this.timeConstraints[ type ].step;
 		if ( value < this.timeConstraints[ type ].min )
 			value = this.timeConstraints[ type ].max + 1 - ( this.timeConstraints[ type ].min - value );
 		return this.pad( type, value );
-	},
+	}
 
-	pad: function( type, value ) {
+	pad( type, value ) {
 		var str = value + '';
 		while ( str.length < this.padValues[ type ] )
 			str = '0' + str;
 		return str;
-	},
-});
+	}
+}
 
 module.exports = DateTimePickerTime;

--- a/src/YearsView.js
+++ b/src/YearsView.js
@@ -1,11 +1,17 @@
 'use strict';
 
-var React = require('react'),
-	createClass = require('create-react-class')
-;
+var React = require('react');
 
-var DateTimePickerYears = createClass({
-	render: function() {
+class DateTimePickerYears extends React.Component {
+	constructor(props) {
+		super(props);
+		this.renderYears = this.renderYears.bind(this);
+		this.updateSelectedYear = this.updateSelectedYear.bind(this);
+		this.renderYear = this.renderYear.bind(this);
+		this.alwaysValidDate = this.alwaysValidDate.bind(this);
+	}
+
+	render() {
 		var year = parseInt( this.props.viewDate.year() / 10, 10 ) * 10;
 
 		return React.createElement('div', { className: 'rdtYears' }, [
@@ -16,9 +22,9 @@ var DateTimePickerYears = createClass({
 			]))),
 			React.createElement('table', { key: 'years' }, React.createElement('tbody',  {}, this.renderYears( year )))
 		]);
-	},
+	}
 
-	renderYears: function( year ) {
+	renderYears( year ) {
 		var years = [],
 			i = -1,
 			rows = [],
@@ -82,19 +88,19 @@ var DateTimePickerYears = createClass({
 		}
 
 		return rows;
-	},
+	}
 
-	updateSelectedYear: function( event ) {
+	updateSelectedYear( event ) {
 		this.props.updateSelectedDate( event );
-	},
+	}
 
-	renderYear: function( props, year ) {
+	renderYear( props, year ) {
 		return React.createElement('td',  props, year );
-	},
+	}
 
-	alwaysValidDate: function() {
+	alwaysValidDate() {
 		return 1;
-	},
-});
+	}
+}
 
 module.exports = DateTimePickerYears;


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the *Title* above -->

### Description
Babel configuration of this project already supports ES2015, so I
converted all the components created by `create-react-class` to
ES2015 classes, and removed the dependency. In addition, I needed
to change JS version of ESLint to ES2015 for making it pass.
<!-- Describe your changes in detail -->

### Motivation and Context
- It removes a dependency.
- It updates the code style.
<!--
  * Why do you think this pull request should be merged?
  * Does it solve a problem, in that case what problem?
  * If these changes fixes an open issue, please provide a link to the issue here
-->

### Checklist
<!--
  The purpose of this checklist is for you to not forget changes you most likely should do. Look 
  through the following points, and put an "x" in all the boxes that apply. If you're unsure about 
  any of these points, then we'd recommend you to read the README. If something still is unclear 
  then don't hesitate to ask. We're here to help!
-->
```
[x] I have not included any built dist files (us maintainers do that prior to a new release)
[x] I have added tests covering my changes
[x] All new and existing tests pass
[ ] My changes required the documentation to be updated
  [ ] I have updated the documentation accordingly
  [ ] I have updated the TypeScript 1.8 type definitions accordingly
  [ ] I have updated the TypeScript 2.0+ type definitions accordingly
```


<!--
  Is there anything in this template you think is confusing, unclear, redundant or just simply bad?
  Please let us know either via creating an issue or creating a PR with changes to it.
-->
