### PR TITLE
Reduce impact on DOM render

### DIFF
--- a/src/datetime/DateTime.js
+++ b/src/datetime/DateTime.js
@@ -59,7 +59,7 @@ export default class Datetime extends React.Component {
 		onCalendarClose: nofn,
 		onChange: nofn,
 		onNavigate: nofn,
-		onBeforeNavigate: function(next) { return next; }, 
+		onBeforeNavigate: function(next) { return next; },
 		onNavigateBack: nofn,
 		onNavigateForward: nofn,
 		dateFormat: true,
@@ -108,7 +108,7 @@ export default class Datetime extends React.Component {
 			onKeyDown: this._onInputKeyDown
 		};
 
-		if ( this.props.renderInput ) {   
+		if ( this.props.renderInput ) {
 			return (
 				<div>
 					{ this.props.renderInput( finalInputProps, this._openCalendar, this._closeCalendar ) }
@@ -122,6 +122,10 @@ export default class Datetime extends React.Component {
 	}
 
 	renderView( currentView, renderer ) {
+		// Don't to DOM if datepicker shouldn't be visible
+		if (!this.isOpen()) {
+			return null;
+		}
 		if ( this.props.renderView ) {
 			return this.props.renderView( currentView, () => renderer(currentView) );
 		}
@@ -150,18 +154,18 @@ export default class Datetime extends React.Component {
 				// { viewDate, selectedDate, renderYear, isValidDate, navigate, showView, updateDate }
 				viewProps.renderYear = props.renderYear;
 				return <YearsView {...viewProps } />;
-			
+
 			case viewModes.MONTHS:
 				// { viewDate, selectedDate, renderMonth, isValidDate, navigate, showView, updateDate }
 				viewProps.renderMonth = props.renderMonth;
 				return <MonthsView {...viewProps} />;
-			
+
 			case viewModes.DAYS:
-				// { viewDate, selectedDate, renderDay, isValidDate, navigate, showView, updateDate, timeFormat 
+				// { viewDate, selectedDate, renderDay, isValidDate, navigate, showView, updateDate, timeFormat
 				viewProps.renderDay = props.renderDay;
 				viewProps.timeFormat = this.getFormat('time');
 				return <DaysView {...viewProps} />;
-			
+
 			default:
 				// { viewDate, selectedDate, timeFormat, dateFormat, timeConstraints, setTime, showView }
 				viewProps.dateFormat = this.getFormat('date');
@@ -187,7 +191,7 @@ export default class Datetime extends React.Component {
 			inputValue: this.getInitialInputValue( props, selectedDate, inputFormat )
 		};
 	}
-	
+
 	getInitialViewDate( propDate, selectedDate, format ) {
 		let viewDate;
 		if ( propDate ) {
@@ -251,7 +255,7 @@ export default class Datetime extends React.Component {
 
 		return cn;
 	}
-	
+
 	isOpen() {
 		return !this.props.input || (this.props.open === undefined ? this.state.open : this.props.open);
 	}
@@ -303,7 +307,7 @@ export default class Datetime extends React.Component {
 		else if ( type === 'time' ) {
 			return this.getTimeFormat( this.getLocaleData() );
 		}
-		
+
 		let locale = this.getLocaleData();
 		let dateFormat = this.getDateFormat( locale );
 		let timeFormat = this.getTimeFormat( locale );
@@ -368,7 +372,7 @@ export default class Datetime extends React.Component {
 
 	_viewNavigate = ( modifier, unit ) => {
 		let viewDate = this.state.viewDate.clone();
-		
+
 		// Subtracting is just adding negative time
 		viewDate.add( modifier, unit );
 
@@ -381,11 +385,11 @@ export default class Datetime extends React.Component {
 
 		this.setState({viewDate});
 	}
-	
+
 	_setTime = ( type, value ) => {
 		const state = this.state;
 		let date = (state.selectedDate || state.viewDate).clone();
-		
+
 		date[ type ]( value );
 
 		if ( !this.props.value ) {
@@ -489,7 +493,7 @@ export default class Datetime extends React.Component {
 		if ( selectedDate && selectedDate.isValid() ) {
 			update.inputValue = selectedDate.format( this.getFormat('datetime') );
 		}
-		
+
 		this.setState( update );
 	}
 
@@ -502,16 +506,16 @@ export default class Datetime extends React.Component {
 	getInitialInputValue( props, selectedDate, inputFormat ) {
 		if ( props.inputProps.value )
 			return props.inputProps.value;
-		
+
 		if ( selectedDate && selectedDate.isValid() )
 			return selectedDate.format( inputFormat );
-		
+
 		if ( props.value && typeof props.value === 'string' )
 			return props.value;
-		
+
 		if ( props.initialValue && typeof props.initialValue === 'string' )
 			return props.initialValue;
-		
+
 		return '';
 	}
 
@@ -533,7 +537,7 @@ export default class Datetime extends React.Component {
 		};
 
 		if ( !date ) return logError();
-		
+
 		let viewDate;
 		if ( typeof date === 'string' ) {
 			viewDate = this.localMoment(date, this.getFormat('datetime') );
@@ -548,7 +552,7 @@ export default class Datetime extends React.Component {
 
 	/**
 	 * Set the view currently shown by the calendar. View modes shipped with react-datetime are 'years', 'months', 'days' and 'time'.
-	 * @param TYPES.string mode 
+	 * @param TYPES.string mode
 	 */
 	navigate( mode ) {
 		this._showView( mode );

--- a/test/__snapshots__/snapshots.spec.js.snap
+++ b/test/__snapshots__/snapshots.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`className: set to arbitraty value 1`] = `
 <div
-  className="rdt arbitrary-value"
+  className="rdt arbitrary-value rdtOpen"
 >
   <input
     className="form-control"
@@ -495,7 +495,7 @@ exports[`className: set to arbitraty value 1`] = `
 
 exports[`dateFormat set to false 1`] = `
 <div
-  className="rdt"
+  className="rdt rdtOpen"
 >
   <input
     className="form-control"
@@ -598,7 +598,7 @@ exports[`dateFormat set to false 1`] = `
 
 exports[`dateFormat set to true 1`] = `
 <div
-  className="rdt"
+  className="rdt rdtOpen"
 >
   <input
     className="form-control"
@@ -1091,7 +1091,7 @@ exports[`dateFormat set to true 1`] = `
 
 exports[`defaultValue: set to arbitrary value 1`] = `
 <div
-  className="rdt"
+  className="rdt rdtOpen"
 >
   <input
     className="form-control"
@@ -1584,7 +1584,7 @@ exports[`defaultValue: set to arbitrary value 1`] = `
 
 exports[`everything default: renders correctly 1`] = `
 <div
-  className="rdt"
+  className="rdt rdtOpen"
 >
   <input
     className="form-control"
@@ -2562,7 +2562,7 @@ exports[`input input: set to false 1`] = `
 
 exports[`input input: set to true 1`] = `
 <div
-  className="rdt"
+  className="rdt rdtOpen"
 >
   <input
     className="form-control"
@@ -3055,7 +3055,7 @@ exports[`input input: set to true 1`] = `
 
 exports[`inputProps with className specified 1`] = `
 <div
-  className="rdt"
+  className="rdt rdtOpen"
 >
   <input
     className="arbitrary-className"
@@ -3548,7 +3548,7 @@ exports[`inputProps with className specified 1`] = `
 
 exports[`inputProps with disabled specified 1`] = `
 <div
-  className="rdt"
+  className="rdt rdtOpen"
 >
   <input
     className="form-control"
@@ -4042,7 +4042,7 @@ exports[`inputProps with disabled specified 1`] = `
 
 exports[`inputProps with name specified 1`] = `
 <div
-  className="rdt"
+  className="rdt rdtOpen"
 >
   <input
     className="form-control"
@@ -4536,7 +4536,7 @@ exports[`inputProps with name specified 1`] = `
 
 exports[`inputProps with placeholder specified 1`] = `
 <div
-  className="rdt"
+  className="rdt rdtOpen"
 >
   <input
     className="form-control"
@@ -5030,7 +5030,7 @@ exports[`inputProps with placeholder specified 1`] = `
 
 exports[`inputProps with required specified 1`] = `
 <div
-  className="rdt"
+  className="rdt rdtOpen"
 >
   <input
     className="form-control"
@@ -5524,7 +5524,7 @@ exports[`inputProps with required specified 1`] = `
 
 exports[`isValidDate: only valid if after yesterday 1`] = `
 <div
-  className="rdt"
+  className="rdt rdtOpen"
 >
   <input
     className="form-control"
@@ -5992,7 +5992,7 @@ exports[`isValidDate: only valid if after yesterday 1`] = `
 
 exports[`open set to false 1`] = `
 <div
-  className="rdt"
+  className="rdt rdtOpen"
 >
   <input
     className="form-control"
@@ -6978,7 +6978,7 @@ exports[`open set to true 1`] = `
 
 exports[`renderDay: specified 1`] = `
 <div
-  className="rdt"
+  className="rdt rdtOpen"
 >
   <input
     className="form-control"
@@ -7471,7 +7471,7 @@ exports[`renderDay: specified 1`] = `
 
 exports[`renderMonth: specified 1`] = `
 <div
-  className="rdt"
+  className="rdt rdtOpen"
 >
   <input
     className="form-control"
@@ -7964,7 +7964,7 @@ exports[`renderMonth: specified 1`] = `
 
 exports[`renderYear: specified 1`] = `
 <div
-  className="rdt"
+  className="rdt rdtOpen"
 >
   <input
     className="form-control"
@@ -8457,7 +8457,7 @@ exports[`renderYear: specified 1`] = `
 
 exports[`timeFormat set to false 1`] = `
 <div
-  className="rdt"
+  className="rdt rdtOpen"
 >
   <input
     className="form-control"
@@ -8939,7 +8939,7 @@ exports[`timeFormat set to false 1`] = `
 
 exports[`timeFormat set to true 1`] = `
 <div
-  className="rdt"
+  className="rdt rdtOpen"
 >
   <input
     className="form-control"
@@ -9432,7 +9432,7 @@ exports[`timeFormat set to true 1`] = `
 
 exports[`value: set to arbitrary value 1`] = `
 <div
-  className="rdt"
+  className="rdt rdtOpen"
 >
   <input
     className="form-control"
@@ -9925,7 +9925,7 @@ exports[`value: set to arbitrary value 1`] = `
 
 exports[`viewMode set to days 1`] = `
 <div
-  className="rdt"
+  className="rdt rdtOpen"
 >
   <input
     className="form-control"
@@ -10418,7 +10418,7 @@ exports[`viewMode set to days 1`] = `
 
 exports[`viewMode set to months 1`] = `
 <div
-  className="rdt"
+  className="rdt rdtOpen"
 >
   <input
     className="form-control"
@@ -10911,7 +10911,7 @@ exports[`viewMode set to months 1`] = `
 
 exports[`viewMode set to time 1`] = `
 <div
-  className="rdt"
+  className="rdt rdtOpen"
 >
   <input
     className="form-control"
@@ -11404,7 +11404,7 @@ exports[`viewMode set to time 1`] = `
 
 exports[`viewMode set to years 1`] = `
 <div
-  className="rdt"
+  className="rdt rdtOpen"
 >
   <input
     className="form-control"

--- a/test/snapshots.spec.js
+++ b/test/snapshots.spec.js
@@ -1,7 +1,7 @@
 /* global it, describe, expect, jest */
 
 import React from 'react'; // eslint-disable-line no-unused-vars
-import Datetime from '../src/datetime/DateTime'; 
+import Datetime from '../src/datetime/DateTime';
 import renderer from 'react-test-renderer';
 
 // findDOMNode is not supported by the react-test-renderer,
@@ -19,21 +19,21 @@ Date.now = jest.fn(() => 1482363367071);
 
 it('everything default: renders correctly', () => {
 	const tree = renderer.create(
-		<Datetime />
+		<Datetime open />
 	).toJSON();
 	expect(tree).toMatchSnapshot();
 });
 
 it('value: set to arbitrary value', () => {
 	const tree = renderer.create(
-		<Datetime defaultValue={Date.now()} />
+		<Datetime defaultValue={Date.now()} open />
 	).toJSON();
 	expect(tree).toMatchSnapshot();
 });
 
 it('defaultValue: set to arbitrary value', () => {
 	const tree = renderer.create(
-		<Datetime defaultValue={Date.now()} />
+		<Datetime defaultValue={Date.now()} open />
 	).toJSON();
 	expect(tree).toMatchSnapshot();
 });
@@ -41,14 +41,14 @@ it('defaultValue: set to arbitrary value', () => {
 describe('dateFormat', () => {
 	it('set to true', () => {
 		const tree = renderer.create(
-			<Datetime dateFormat={true} />
+			<Datetime dateFormat={true} open />
 		).toJSON();
 		expect(tree).toMatchSnapshot();
 	});
 
 	it('set to false', () => {
 		const tree = renderer.create(
-			<Datetime dateFormat={false} />
+			<Datetime dateFormat={false} open />
 		).toJSON();
 		expect(tree).toMatchSnapshot();
 	});
@@ -57,14 +57,14 @@ describe('dateFormat', () => {
 describe('timeFormat', () => {
 	it('set to true', () => {
 		const tree = renderer.create(
-			<Datetime timeFormat={true} />
+			<Datetime timeFormat={true} open />
 		).toJSON();
 		expect(tree).toMatchSnapshot();
 	});
 
 	it('set to false', () => {
 		const tree = renderer.create(
-			<Datetime timeFormat={false} />
+			<Datetime timeFormat={false} open />
 		).toJSON();
 		expect(tree).toMatchSnapshot();
 	});
@@ -73,14 +73,14 @@ describe('timeFormat', () => {
 describe('input', () => {
 	it('input: set to true', () => {
 		const tree = renderer.create(
-			<Datetime input={true} />
+			<Datetime input={true} open />
 		).toJSON();
 		expect(tree).toMatchSnapshot();
 	});
 
 	it('input: set to false', () => {
 		const tree = renderer.create(
-			<Datetime input={false} />
+			<Datetime input={false} open />
 		).toJSON();
 		expect(tree).toMatchSnapshot();
 	});
@@ -89,14 +89,14 @@ describe('input', () => {
 describe('open', () => {
 	it('set to true', () => {
 		const tree = renderer.create(
-			<Datetime open={true} />
+			<Datetime open={true} open />
 		).toJSON();
 		expect(tree).toMatchSnapshot();
 	});
 
 	it('set to false', () => {
 		const tree = renderer.create(
-			<Datetime open={false} />
+			<Datetime open={false} open />
 		).toJSON();
 		expect(tree).toMatchSnapshot();
 	});
@@ -105,28 +105,28 @@ describe('open', () => {
 describe('viewMode', () => {
 	it('set to days', () => {
 		const tree = renderer.create(
-			<Datetime viewMode={'days'} />
+			<Datetime viewMode={'days'} open />
 		).toJSON();
 		expect(tree).toMatchSnapshot();
 	});
 
 	it('set to months', () => {
 		const tree = renderer.create(
-			<Datetime viewMode={'months'} />
+			<Datetime viewMode={'months'} open />
 		).toJSON();
 		expect(tree).toMatchSnapshot();
 	});
 
 	it('set to years', () => {
 		const tree = renderer.create(
-			<Datetime viewMode={'years'} />
+			<Datetime viewMode={'years'} open />
 		).toJSON();
 		expect(tree).toMatchSnapshot();
 	});
 
 	it('set to time', () => {
 		const tree = renderer.create(
-			<Datetime viewMode={'time'} />
+			<Datetime viewMode={'time'} open />
 		).toJSON();
 		expect(tree).toMatchSnapshot();
 	});
@@ -134,7 +134,7 @@ describe('viewMode', () => {
 
 it('className: set to arbitraty value', () => {
 	const tree = renderer.create(
-		<Datetime className={'arbitrary-value'} />
+		<Datetime className={'arbitrary-value'} open />
 	).toJSON();
 	expect(tree).toMatchSnapshot();
 });
@@ -142,35 +142,35 @@ it('className: set to arbitraty value', () => {
 describe('inputProps', () => {
 	it('with placeholder specified', () => {
 		const tree = renderer.create(
-			<Datetime inputProps={{ placeholder: 'arbitrary-placeholder' }} />
+			<Datetime inputProps={{ placeholder: 'arbitrary-placeholder' }} open />
 		).toJSON();
 		expect(tree).toMatchSnapshot();
 	});
 
 	it('with disabled specified', () => {
 		const tree = renderer.create(
-			<Datetime inputProps={{ disabled: true }} />
+			<Datetime inputProps={{ disabled: true }} open />
 		).toJSON();
 		expect(tree).toMatchSnapshot();
 	});
 
 	it('with required specified', () => {
 		const tree = renderer.create(
-			<Datetime inputProps={{ required: true }} />
+			<Datetime inputProps={{ required: true }} open />
 		).toJSON();
 		expect(tree).toMatchSnapshot();
 	});
 
 	it('with name specified', () => {
 		const tree = renderer.create(
-			<Datetime inputProps={{ name: 'arbitrary-name' }} />
+			<Datetime inputProps={{ name: 'arbitrary-name' }} open />
 		).toJSON();
 		expect(tree).toMatchSnapshot();
 	});
 
 	it('with className specified', () => {
 		const tree = renderer.create(
-			<Datetime inputProps={{ className: 'arbitrary-className' }} />
+			<Datetime inputProps={{ className: 'arbitrary-className' }} open />
 		).toJSON();
 		expect(tree).toMatchSnapshot();
 	});
@@ -180,7 +180,7 @@ it('isValidDate: only valid if after yesterday', () => {
 	const yesterday = Datetime.moment().subtract(1, 'day');
 	const valid = (current) => current.isAfter(yesterday);
 	const tree = renderer.create(
-		<Datetime isValidDate={ valid } />
+		<Datetime isValidDate={ valid } open />
 	).toJSON();
 	expect(tree).toMatchSnapshot();
 });
@@ -188,7 +188,7 @@ it('isValidDate: only valid if after yesterday', () => {
 it('renderDay: specified', () => {
 	const renderDay = (props, currentDate) => <td {...props}>{ '0' + currentDate.date() }</td>;
 	const tree = renderer.create(
-		<Datetime renderDay={renderDay} />
+		<Datetime renderDay={renderDay} open />
 	).toJSON();
 	expect(tree).toMatchSnapshot();
 });
@@ -196,7 +196,7 @@ it('renderDay: specified', () => {
 it('renderMonth: specified', () => {
 	const renderMonth = (props, currentDate) => <td {...props}>{ '0' + currentDate.date() }</td>;
 	const tree = renderer.create(
-		<Datetime renderMonth={renderMonth} />
+		<Datetime renderMonth={renderMonth} open />
 	).toJSON();
 	expect(tree).toMatchSnapshot();
 });
@@ -204,7 +204,7 @@ it('renderMonth: specified', () => {
 it('renderYear: specified', () => {
 	const renderYear = (props, currentDate) => <td {...props}>{ '0' + currentDate.date() }</td>;
 	const tree = renderer.create(
-		<Datetime renderYear={renderYear} />
+		<Datetime renderYear={renderYear} open />
 	).toJSON();
 	expect(tree).toMatchSnapshot();
 });


### PR DESCRIPTION
**Description**
Multiple datePickers on one page can cause the DOM rendering to slow down.
In my current project we have tables with 20 to 100 row that can be edited and we see the DOM becomes very big.

**Motivation and Context**
- Amount of nodes in the dom before the change: 71
- Amount of nodes in the dom after the change: 2

(Done with document.querySelector(".rdt").getElementsByTagName('*').length)

**Checklist**
[x] I have not included any built dist files (us maintainers do that prior to a new release)
[ ] I have added tests covering my changes
[x] All new and existing tests pass
[ ] My changes required the documentation to be updated
  [ ] I have updated the documentation accordingly
  [ ] I have updated the TypeScript 1.8 type definitions accordingly
  [ ] I have updated the TypeScript 2.0+ type definitions accordingly
