### PR TITLE
Add default render props

### DIFF
--- a/src/datetime/DateTime.js
+++ b/src/datetime/DateTime.js
@@ -73,7 +73,8 @@ export default class Datetime extends React.Component {
 		strictParsing: true,
 		closeOnSelect: false,
 		closeOnTab: true,
-		closeOnClickOutside: true
+		closeOnClickOutside: true,
+		renderView: ( _, renderFunc ) => renderFunc(),
 	}
 
 	// Make moment accessible through the Datetime class
@@ -123,10 +124,7 @@ export default class Datetime extends React.Component {
 	}
 
 	renderView() {
-		if ( this.props.renderView ) {
-			return this.props.renderView( this.state.currentView, this._renderCalendar );
-		}
-		return this._renderCalendar();
+		return this.props.renderView( this.state.currentView, this._renderCalendar );
 	}
 
 	_renderCalendar = () => {

--- a/src/datetime/DaysView.js
+++ b/src/datetime/DaysView.js
@@ -3,7 +3,8 @@ import ViewNavigation from './ViewNavigation';
 
 export default class DaysView extends React.Component {
 	static defaultProps = {
-		isValidDate: () => true
+		isValidDate: () => true,
+		renderDay: ( props, date ) => <td { ...props }>{ date.date() }</td>,
 	}
 
 	render() {
@@ -110,14 +111,8 @@ export default class DaysView extends React.Component {
 
 		dayProps.className = className;
 
-		if ( this.props.renderDay ) {
-			return this.props.renderDay(
-				dayProps, date.clone(), selectedDate && selectedDate.clone()
-			);
-		}
-
-		return (
-			<td { ...dayProps }>{ date.date() }</td>
+		return this.props.renderDay(
+			dayProps, date.clone(), selectedDate && selectedDate.clone()
 		);
 	}
 

--- a/src/datetime/YearsView.js
+++ b/src/datetime/YearsView.js
@@ -2,6 +2,10 @@ import React from 'react';
 import ViewNavigation from './ViewNavigation';
 
 export default class YearsView extends React.Component {
+	static defaultProps = {
+		renderYear: ( props, year ) => <td { ...props }>{ year }</td>,
+	};
+
 	render() {
 		return (
 			<div className="rdtYears">
@@ -66,18 +70,10 @@ export default class YearsView extends React.Component {
 
 		let props = {key: year, className, 'data-value': year, onClick };
 
-		if ( this.props.renderYear ) {
-			return this.props.renderYear(
-				props,
-				year,
-				this.props.selectedDate && this.props.selectedDate.clone()
-			);
-		}
-
-		return (
-			<td { ...props }>
-				{ year }
-			</td>
+		return this.props.renderYear(
+			props,
+			year,
+			this.props.selectedDate && this.props.selectedDate.clone()
 		);
 	}
 


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the *Title* above -->

### Description
Moved the default implementation of rendering to default props,
reducing the branching. I couldn't change `renderInput` (custom
implementations get wrapped by a `div`, default one doesn't) and
`renderMonth` (default implementation depends on state) trivially,
so I left them out of this PR's scope.
<!-- Describe your changes in detail -->

### Motivation and Context
<!--
  * Why do you think this pull request should be merged?
  * Does it solve a problem, in that case what problem?
  * If these changes fixes an open issue, please provide a link to the issue here
-->
- Simplifies the code
- Reduces branching

### Checklist
<!--
  The purpose of this checklist is for you to not forget changes you most likely should do. Look 
  through the following points, and put an "x" in all the boxes that apply. If you're unsure about 
  any of these points, then we'd recommend you to read the README. If something still is unclear 
  then don't hesitate to ask. We're here to help!
-->
```
[x] I have not included any built dist files (us maintainers do that prior to a new release)
[ ] I have added tests covering my changes
[x] All new and existing tests pass
[ ] My changes required the documentation to be updated
  [ ] I have updated the documentation accordingly
  [ ] I have updated the TypeScript 1.8 type definitions accordingly
  [ ] I have updated the TypeScript 2.0+ type definitions accordingly
```


<!--
  Is there anything in this template you think is confusing, unclear, redundant or just simply bad?
  Please let us know either via creating an issue or creating a PR with changes to it.
-->
