### PR TITLE
Fix CI build issues related to npm v7

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,6 @@
     "postcss-safe-parser": "4.0.1",
     "pre-commit": "^1.1.3",
     "react": "^16.5.0",
-    "react-addons-test-utils": ">=0.13",
     "react-app-polyfill": "^1.0.5",
     "react-dev-utils": "10.1.0",
     "react-dom": "^16.5.0",


### PR DESCRIPTION
### Description
Travis CI build failed for PR #757 due to breaking changes introduced with npm v7. Here's the part of the log related to this issue. 

```
$ npm install 
214npm ERR! code ERESOLVE
215npm ERR! ERESOLVE unable to resolve dependency tree
216npm ERR! 
217npm ERR! While resolving: react-datetime@3.0.4
218npm ERR! Found: react-dom@16.14.0
219npm ERR! node_modules/react-dom
220npm ERR!   dev react-dom@"^16.5.0" from the root project
221npm ERR! 
222npm ERR! Could not resolve dependency:
223npm ERR! peer react-dom@"^15.4.2" from react-addons-test-utils@15.6.2
224npm ERR! node_modules/react-addons-test-utils
225npm ERR!   dev react-addons-test-utils@">=0.13" from the root project
226npm ERR! 
227npm ERR! Fix the upstream dependency conflict, or retry
228npm ERR! this command with --force, or --legacy-peer-deps
229npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
230npm ERR! 
231npm ERR! See /home/travis/.npm/eresolve-report.txt for a full report.
```

The root cause for this issue was due to `react-addons-test-utils` which was not used anywhere. All test cases pass and the playground code runs fine after removing this package from devDependencies.

### Checklist
```
[x] I have not included any built dist files (us maintainers do that prior to a new release)
[ ] I have added tests covering my changes
[x] All new and existing tests pass
[ ] My changes required the documentation to be updated
  [ ] I have updated the documentation accordingly
  [ ] I have updated the TypeScript 1.8 type definitions accordingly
  [ ] I have updated the TypeScript 2.0+ type definitions accordingly
```
