### PR TITLE
Allow react 17 as peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "license": "MIT",
   "peerDependencies": {
     "moment": "^2.16.0",
-    "react": "^16.5.0"
+    "react": "^16.5.0 || ^17.0.0"
   },
   "devDependencies": {
     "@babel/core": "7.7.4",


### PR DESCRIPTION
Adds react 17 as peerDependency to prevent warnings.

### Description
Allows react 17 as peerDependency
fixes #792
fixes #774

### Motivation and Context
react-datetime works with react 17.

Testing against react 17 is blocked by enzyme-adapter-17, which still in development: https://github.com/enzymejs/enzyme/pull/2430

### Checklist
```
[X] I have not included any built dist files (us maintainers do that prior to a new release)
[ ] I have added tests covering my changes
[X] All new and existing tests pass
[ ] My changes required the documentation to be updated
  [ ] I have updated the documentation accordingly
  [ ] I have updated the TypeScript 1.8 type definitions accordingly
  [ ] I have updated the TypeScript 2.0+ type definitions accordingly
```


<!--
  Is there anything in this template you think is confusing, unclear, redundant or just simply bad?
  Please let us know either via creating an issue or creating a PR with changes to it.
-->
