### PR TITLE
Support allowSyntheticDefaultImports: false

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ required.
 Typings for 1.8 are found in `react-datetime.d.ts` and typings for 2.0 are found in `typings/index.d.ts`.
 
 ```js
-import * as Datetime from 'react-datetime';
+import Datetime from 'react-datetime';
 
 class MyDTPicker extends React.Component<MyDTPickerProps, MyDTPickerState> {
     render() JSX.Element {

--- a/typings/DateTime.d.ts
+++ b/typings/DateTime.d.ts
@@ -8,7 +8,7 @@
 import { Component, ChangeEvent, FocusEvent, FocusEventHandler } from 'react';
 import { Moment } from 'moment';
 
-export = ReactDatetimeClass;
+export default ReactDatetimeClass;
 
 declare namespace ReactDatetimeClass {
     /*


### PR DESCRIPTION
Now that ES6-ported class exported properly as default, typings still forcing us to import it like "`* as DatetimeModule`" and then extract its default field to use as a component:
`const Datetime = (DatetimeModule as any).default;`