### PR TITLE
Pass cloned date to `isValidDate` to render days

### DIFF
--- a/src/views/DaysView.js
+++ b/src/views/DaysView.js
@@ -102,7 +102,7 @@ export default class DaysView extends React.Component {
 			className += ' rdtToday';
 		}
 
-		if ( this.props.isValidDate(date) ) {
+		if ( this.props.isValidDate(date.clone()) ) {
 			dayProps.onClick = this._setDate;
 		}
 		else {


### PR DESCRIPTION
### Description
Avoid rendering days side effects by cloning the date to be
verified against the `isValidDate` function.

### Motivation and Context
This solves an important issue in the library, if for some reason
you mutate the input date in the `isValidDate` function, the `renderDay`
method will render the mutated date instead of the original.

### Checklist
```
[x] I have not included any built dist files (us maintainers do that prior to a new release)
[ ] I have added tests covering my changes
[x] All new and existing tests pass
[ ] My changes required the documentation to be updated
  [ ] I have updated the documentation accordingly
  [ ] I have updated the TypeScript 1.8 type definitions accordingly
  [ ] I have updated the TypeScript 2.0+ type definitions accordingly
```
