### PR TITLE
[Feature] Add useFixedPosition prop to render picker outside an "overflow: hidden" div

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Below we have all the props that we can use with the `<DateTime>` component. The
 | **closeOnTab** | `boolean` | `true` | When `true` and the input is focused, pressing the `tab` key will close the datepicker.
 | **timeConstraints** | `object` | `null` | Add some constraints to the timepicker. It accepts an `object` with the format `{ hours: { min: 9, max: 15, step: 2 }}`, this example means the hours can't be lower than `9` and higher than `15`, and it will change adding or subtracting `2` hours everytime the buttons are clicked. The constraints can be added to the `hours`, `minutes`, `seconds` and `milliseconds`.
 | **closeOnClickOutside** | `boolean` | `true` | When the calendar is open and `closeOnClickOutside` is `true` (its default value), clickin outside of the calendar or input closes the calendar. If `false` the calendar stays open.
+| **useFixedPosition** | `boolean` | `false` | Forces the picker element to render in a fixed window position, calculating it's coordinates based on it's wrapper. Useful for cases when the datepicker is rendered inside a div with hidden overflow that otherwise would be cropping the component.
 
 ## Imperative API
 Besides controlling the selected date, there is a navigation through months, years, decades that react-datetime handles for us. We can interfere in it, stopping view transtions by using the prop `onBeforeNavigate`, but we can also navigate to a specific view and date by using some imperative methods.

--- a/react-datetime.d.ts
+++ b/react-datetime.d.ts
@@ -186,6 +186,12 @@ declare module ReactDatetime {
      When true the picker get closed when clicking outside of the calendar or the input box. When false, it stays open.
      */
     closeOnClickOutside?: boolean;
+    /*
+    Forces the picker element to render in a fixed window position, calculating it's coordinates based
+    on it's wrapper. Useful for cases when the datepicker is rendered inside a div with hidden overflow
+    that otherwise would be cropping the component.
+    */
+    useFixedPosition?: boolean;
   }
 
   interface DatetimeComponent extends React.ComponentClass<DatetimepickerProps> {

--- a/src/DateTime.js
+++ b/src/DateTime.js
@@ -50,6 +50,7 @@ export default class Datetime extends React.Component {
 		renderDay: TYPES.func,
 		renderMonth: TYPES.func,
 		renderYear: TYPES.func,
+		useFixedPosition: TYPES.bool,
 	}
 
 	static defaultProps = {
@@ -83,13 +84,17 @@ export default class Datetime extends React.Component {
 	constructor( props ) {
 		super( props );
 		this.state = this.getInitialState();
+		this.wrapper = React.createRef();
+		this.picker = React.createRef();
 	}
 
 	render() {
+		this.props.useFixedPosition && this._updatePickerFixedPosition();
+
 		return (
 			<ClickableWrapper className={ this.getClassName() } onClickOut={ this._handleClickOutside }>
 				{ this.renderInput() }
-				<div className="rdtPicker">
+				<div ref={this.picker} className="rdtPicker" style={this.props.useFixedPosition && { position: 'fixed' }}>
 					{ this.renderView() }
 				</div>
 			</ClickableWrapper>
@@ -112,7 +117,7 @@ export default class Datetime extends React.Component {
 
 		if ( this.props.renderInput ) {   
 			return (
-				<div>
+				<div ref={this.wrapper}>
 					{ this.props.renderInput( finalInputProps, this._openCalendar, this._closeCalendar ) }
 				</div>
 			);
@@ -125,6 +130,14 @@ export default class Datetime extends React.Component {
 
 	renderView() {
 		return this.props.renderView( this.state.currentView, this._renderCalendar );
+	}
+
+	_updatePickerFixedPosition() {
+		if (this.picker.current && this.wrapper.current) {
+			const wrapperBounds = this.wrapper.current.getBoundingClientRect();
+			this.picker.current.style.left = `${wrapperBounds.left}px`;
+			this.picker.current.style.top = `${wrapperBounds.top + wrapperBounds.height}px`;
+		}
 	}
 
 	_renderCalendar = () => {

--- a/test/__snapshots__/snapshots.spec.js.snap
+++ b/test/__snapshots__/snapshots.spec.js.snap
@@ -310,7 +310,7 @@ exports[`className: set to arbitraty value 1`] = `
               20
             </td>
             <td
-              className="rdtDay"
+              className="rdtDay rdtToday"
               data-month={11}
               data-value={21}
               data-year={2016}
@@ -319,7 +319,7 @@ exports[`className: set to arbitraty value 1`] = `
               21
             </td>
             <td
-              className="rdtDay rdtToday"
+              className="rdtDay"
               data-month={11}
               data-value={22}
               data-year={2016}
@@ -908,7 +908,7 @@ exports[`dateFormat set to true 1`] = `
               20
             </td>
             <td
-              className="rdtDay"
+              className="rdtDay rdtToday"
               data-month={11}
               data-value={21}
               data-year={2016}
@@ -917,7 +917,7 @@ exports[`dateFormat set to true 1`] = `
               21
             </td>
             <td
-              className="rdtDay rdtToday"
+              className="rdtDay"
               data-month={11}
               data-value={22}
               data-year={2016}
@@ -1402,7 +1402,7 @@ exports[`defaultValue: set to arbitrary value 1`] = `
               20
             </td>
             <td
-              className="rdtDay"
+              className="rdtDay rdtToday"
               data-month={11}
               data-value={21}
               data-year={2016}
@@ -1411,7 +1411,7 @@ exports[`defaultValue: set to arbitrary value 1`] = `
               21
             </td>
             <td
-              className="rdtDay rdtToday"
+              className="rdtDay"
               data-month={11}
               data-value={22}
               data-year={2016}
@@ -1896,7 +1896,7 @@ exports[`everything default: renders correctly 1`] = `
               20
             </td>
             <td
-              className="rdtDay"
+              className="rdtDay rdtToday"
               data-month={11}
               data-value={21}
               data-year={2016}
@@ -1905,7 +1905,7 @@ exports[`everything default: renders correctly 1`] = `
               21
             </td>
             <td
-              className="rdtDay rdtToday"
+              className="rdtDay"
               data-month={11}
               data-value={22}
               data-year={2016}
@@ -2381,7 +2381,7 @@ exports[`input input: set to false 1`] = `
               20
             </td>
             <td
-              className="rdtDay"
+              className="rdtDay rdtToday"
               data-month={11}
               data-value={21}
               data-year={2016}
@@ -2390,7 +2390,7 @@ exports[`input input: set to false 1`] = `
               21
             </td>
             <td
-              className="rdtDay rdtToday"
+              className="rdtDay"
               data-month={11}
               data-value={22}
               data-year={2016}
@@ -2875,7 +2875,7 @@ exports[`input input: set to true 1`] = `
               20
             </td>
             <td
-              className="rdtDay"
+              className="rdtDay rdtToday"
               data-month={11}
               data-value={21}
               data-year={2016}
@@ -2884,7 +2884,7 @@ exports[`input input: set to true 1`] = `
               21
             </td>
             <td
-              className="rdtDay rdtToday"
+              className="rdtDay"
               data-month={11}
               data-value={22}
               data-year={2016}
@@ -3369,7 +3369,7 @@ exports[`inputProps with className specified 1`] = `
               20
             </td>
             <td
-              className="rdtDay"
+              className="rdtDay rdtToday"
               data-month={11}
               data-value={21}
               data-year={2016}
@@ -3378,7 +3378,7 @@ exports[`inputProps with className specified 1`] = `
               21
             </td>
             <td
-              className="rdtDay rdtToday"
+              className="rdtDay"
               data-month={11}
               data-value={22}
               data-year={2016}
@@ -3864,7 +3864,7 @@ exports[`inputProps with disabled specified 1`] = `
               20
             </td>
             <td
-              className="rdtDay"
+              className="rdtDay rdtToday"
               data-month={11}
               data-value={21}
               data-year={2016}
@@ -3873,7 +3873,7 @@ exports[`inputProps with disabled specified 1`] = `
               21
             </td>
             <td
-              className="rdtDay rdtToday"
+              className="rdtDay"
               data-month={11}
               data-value={22}
               data-year={2016}
@@ -4359,7 +4359,7 @@ exports[`inputProps with name specified 1`] = `
               20
             </td>
             <td
-              className="rdtDay"
+              className="rdtDay rdtToday"
               data-month={11}
               data-value={21}
               data-year={2016}
@@ -4368,7 +4368,7 @@ exports[`inputProps with name specified 1`] = `
               21
             </td>
             <td
-              className="rdtDay rdtToday"
+              className="rdtDay"
               data-month={11}
               data-value={22}
               data-year={2016}
@@ -4854,7 +4854,7 @@ exports[`inputProps with placeholder specified 1`] = `
               20
             </td>
             <td
-              className="rdtDay"
+              className="rdtDay rdtToday"
               data-month={11}
               data-value={21}
               data-year={2016}
@@ -4863,7 +4863,7 @@ exports[`inputProps with placeholder specified 1`] = `
               21
             </td>
             <td
-              className="rdtDay rdtToday"
+              className="rdtDay"
               data-month={11}
               data-value={22}
               data-year={2016}
@@ -5349,7 +5349,7 @@ exports[`inputProps with required specified 1`] = `
               20
             </td>
             <td
-              className="rdtDay"
+              className="rdtDay rdtToday"
               data-month={11}
               data-value={21}
               data-year={2016}
@@ -5358,7 +5358,7 @@ exports[`inputProps with required specified 1`] = `
               21
             </td>
             <td
-              className="rdtDay rdtToday"
+              className="rdtDay"
               data-month={11}
               data-value={22}
               data-year={2016}
@@ -5819,15 +5819,16 @@ exports[`isValidDate: only valid if after yesterday 1`] = `
               20
             </td>
             <td
-              className="rdtDay rdtDisabled"
+              className="rdtDay rdtToday"
               data-month={11}
               data-value={21}
               data-year={2016}
+              onClick={[Function]}
             >
               21
             </td>
             <td
-              className="rdtDay rdtToday"
+              className="rdtDay"
               data-month={11}
               data-value={22}
               data-year={2016}
@@ -6312,7 +6313,7 @@ exports[`open set to false 1`] = `
               20
             </td>
             <td
-              className="rdtDay"
+              className="rdtDay rdtToday"
               data-month={11}
               data-value={21}
               data-year={2016}
@@ -6321,7 +6322,7 @@ exports[`open set to false 1`] = `
               21
             </td>
             <td
-              className="rdtDay rdtToday"
+              className="rdtDay"
               data-month={11}
               data-value={22}
               data-year={2016}
@@ -6806,7 +6807,7 @@ exports[`open set to true 1`] = `
               20
             </td>
             <td
-              className="rdtDay"
+              className="rdtDay rdtToday"
               data-month={11}
               data-value={21}
               data-year={2016}
@@ -6815,7 +6816,7 @@ exports[`open set to true 1`] = `
               21
             </td>
             <td
-              className="rdtDay rdtToday"
+              className="rdtDay"
               data-month={11}
               data-value={22}
               data-year={2016}
@@ -7300,7 +7301,7 @@ exports[`renderDay: specified 1`] = `
               020
             </td>
             <td
-              className="rdtDay"
+              className="rdtDay rdtToday"
               data-month={11}
               data-value={21}
               data-year={2016}
@@ -7309,7 +7310,7 @@ exports[`renderDay: specified 1`] = `
               021
             </td>
             <td
-              className="rdtDay rdtToday"
+              className="rdtDay"
               data-month={11}
               data-value={22}
               data-year={2016}
@@ -7794,7 +7795,7 @@ exports[`renderMonth: specified 1`] = `
               20
             </td>
             <td
-              className="rdtDay"
+              className="rdtDay rdtToday"
               data-month={11}
               data-value={21}
               data-year={2016}
@@ -7803,7 +7804,7 @@ exports[`renderMonth: specified 1`] = `
               21
             </td>
             <td
-              className="rdtDay rdtToday"
+              className="rdtDay"
               data-month={11}
               data-value={22}
               data-year={2016}
@@ -8288,7 +8289,7 @@ exports[`renderYear: specified 1`] = `
               20
             </td>
             <td
-              className="rdtDay"
+              className="rdtDay rdtToday"
               data-month={11}
               data-value={21}
               data-year={2016}
@@ -8297,7 +8298,7 @@ exports[`renderYear: specified 1`] = `
               21
             </td>
             <td
-              className="rdtDay rdtToday"
+              className="rdtDay"
               data-month={11}
               data-value={22}
               data-year={2016}
@@ -8782,7 +8783,7 @@ exports[`timeFormat set to false 1`] = `
               20
             </td>
             <td
-              className="rdtDay"
+              className="rdtDay rdtToday"
               data-month={11}
               data-value={21}
               data-year={2016}
@@ -8791,7 +8792,7 @@ exports[`timeFormat set to false 1`] = `
               21
             </td>
             <td
-              className="rdtDay rdtToday"
+              className="rdtDay"
               data-month={11}
               data-value={22}
               data-year={2016}
@@ -9265,7 +9266,7 @@ exports[`timeFormat set to true 1`] = `
               20
             </td>
             <td
-              className="rdtDay"
+              className="rdtDay rdtToday"
               data-month={11}
               data-value={21}
               data-year={2016}
@@ -9274,7 +9275,7 @@ exports[`timeFormat set to true 1`] = `
               21
             </td>
             <td
-              className="rdtDay rdtToday"
+              className="rdtDay"
               data-month={11}
               data-value={22}
               data-year={2016}
@@ -9759,7 +9760,7 @@ exports[`value: set to arbitrary value 1`] = `
               20
             </td>
             <td
-              className="rdtDay"
+              className="rdtDay rdtToday"
               data-month={11}
               data-value={21}
               data-year={2016}
@@ -9768,7 +9769,7 @@ exports[`value: set to arbitrary value 1`] = `
               21
             </td>
             <td
-              className="rdtDay rdtToday"
+              className="rdtDay"
               data-month={11}
               data-value={22}
               data-year={2016}
@@ -10253,7 +10254,7 @@ exports[`viewMode set to days 1`] = `
               20
             </td>
             <td
-              className="rdtDay"
+              className="rdtDay rdtToday"
               data-month={11}
               data-value={21}
               data-year={2016}
@@ -10262,7 +10263,7 @@ exports[`viewMode set to days 1`] = `
               21
             </td>
             <td
-              className="rdtDay rdtToday"
+              className="rdtDay"
               data-month={11}
               data-value={22}
               data-year={2016}
@@ -10747,7 +10748,7 @@ exports[`viewMode set to months 1`] = `
               20
             </td>
             <td
-              className="rdtDay"
+              className="rdtDay rdtToday"
               data-month={11}
               data-value={21}
               data-year={2016}
@@ -10756,7 +10757,7 @@ exports[`viewMode set to months 1`] = `
               21
             </td>
             <td
-              className="rdtDay rdtToday"
+              className="rdtDay"
               data-month={11}
               data-value={22}
               data-year={2016}
@@ -11241,7 +11242,7 @@ exports[`viewMode set to time 1`] = `
               20
             </td>
             <td
-              className="rdtDay"
+              className="rdtDay rdtToday"
               data-month={11}
               data-value={21}
               data-year={2016}
@@ -11250,7 +11251,7 @@ exports[`viewMode set to time 1`] = `
               21
             </td>
             <td
-              className="rdtDay rdtToday"
+              className="rdtDay"
               data-month={11}
               data-value={22}
               data-year={2016}
@@ -11735,7 +11736,7 @@ exports[`viewMode set to years 1`] = `
               20
             </td>
             <td
-              className="rdtDay"
+              className="rdtDay rdtToday"
               data-month={11}
               data-value={21}
               data-year={2016}
@@ -11744,7 +11745,7 @@ exports[`viewMode set to years 1`] = `
               21
             </td>
             <td
-              className="rdtDay rdtToday"
+              className="rdtDay"
               data-month={11}
               data-value={22}
               data-year={2016}

--- a/test/testUtils.js
+++ b/test/testUtils.js
@@ -137,5 +137,12 @@ module.exports = {
 
 	getViewDateValue: (datetime) => {
 		return datetime.find('.rdtSwitch').getDOMNode().innerHTML;
-	}
+	},
+
+	/*
+	* Get CSS
+	*/
+	getPickerStyleProp: (datetime) => {
+		return datetime.find('.rdtPicker').props().style;
+	},
 };

--- a/test/tests.spec.js
+++ b/test/tests.spec.js
@@ -820,6 +820,12 @@ describe('Datetime', () => {
 			}, 0);
 		});
 
+		it('useFixedPosition=true changes rdtPicker position to fixed', () => {
+			const component = utils.createDatetime({ useFixedPosition: true });
+			utils.openDatepicker(component);
+			expect(utils.getPickerStyleProp(component).position).toEqual('fixed');
+		});
+
 		describe('initialValue of type', () => {
 			it('date', () => {
 				const date = new Date(2000, 0, 15, 2, 2, 2, 2),

--- a/typings/DateTime.d.ts
+++ b/typings/DateTime.d.ts
@@ -201,6 +201,12 @@ declare namespace ReactDatetimeClass {
          When true the picker get closed when clicking outside of the calendar or the input box. When false, it stays open.
          */
         closeOnClickOutside?: boolean;
+        /*
+        Forces the picker element to render in a fixed window position, calculating it's coordinates based
+        on it's wrapper. Useful for cases when the datepicker is rendered inside a div with hidden overflow
+        that otherwise would be cropping the component.
+        */
+        useFixedPosition?: boolean;
     }
 
     export interface DatetimepickerState {


### PR DESCRIPTION
### Description
This PR adds new optional flag, so users can force fixed position rendering and then calculating it's position based on datepicker's wrapper. This is useful in cases where the datepicker is rendered inside a div with hidden overflow and the view is being cropped.

### Motivation and Context
I developed this solution while working on a dynamic table that would scroll laterally, with datepickers as headers. When the table had just a few or no rows, the div container would severely crop datepicker's view.

Default datepicker
![datepicker1](https://user-images.githubusercontent.com/7242526/109558737-8fcbc780-7ab8-11eb-9635-b7a6a2924f2f.png)

WIth applied solution:
![datepicker2](https://user-images.githubusercontent.com/7242526/109558738-90645e00-7ab8-11eb-9753-2be3aefd478c.png)

Also, this PR should solve [issue 186](https://github.com/arqex/react-datetime/issues/186)

### Checklist
```
[X] I have not included any built dist files (us maintainers do that prior to a new release)
[X] I have added tests covering my changes
[X] All new and existing tests pass
[X] My changes required the documentation to be updated
  [X] I have updated the documentation accordingly
  [X] I have updated the TypeScript 1.8 type definitions accordingly
  [X] I have updated the TypeScript 2.0+ type definitions accordingly
```