### PR TITLE
[Bug] Incorrect years range is displayed in the viewMode header

### DIFF
--- a/src/views/YearsView.js
+++ b/src/views/YearsView.js
@@ -30,7 +30,7 @@ export default class YearsView extends React.Component {
 				onClickPrev={ () => this.props.navigate( -10, 'years' ) }
 				onClickSwitch={ () => this.props.showView( 'years' ) }
 				onClickNext={ () => this.props.navigate( 10, 'years' ) }
-				switchContent={ `${viewYear}-${viewYear + 9}` }
+				switchContent={ `${viewYear - 1}-${viewYear + 10}` }
 			/>
 		);
 	}

--- a/test/tests.spec.js
+++ b/test/tests.spec.js
@@ -125,7 +125,7 @@ describe('Datetime', () => {
 		const date = new Date(2000, 0, 15, 2, 2, 2, 2),
 			component = utils.createDatetime({ initialViewMode: 'years', initialValue: date });
 		expect(utils.isYearView(component)).toBeTruthy();
-		expect(component.find('.rdtSwitch').text()).toEqual('2000-2009');
+		expect(component.find('.rdtSwitch').text()).toEqual('1999-2010');
 
 		// Click first year (1999)
 		utils.clickOnElement(component.find('.rdtYear').at(0));
@@ -137,22 +137,22 @@ describe('Datetime', () => {
 		const date = new Date(2000, 0, 15, 2, 2, 2, 2),
 			component = utils.createDatetime({ initialViewMode: 'years', initialValue: date });
 
-		expect(component.find('.rdtSwitch').text()).toEqual('2000-2009');
+		expect(component.find('.rdtSwitch').text()).toEqual('1999-2010');
 		utils.clickOnElement(component.find('.rdtNext span').at(0));
-		expect(component.find('.rdtSwitch').text()).toEqual('2010-2019');
+		expect(component.find('.rdtSwitch').text()).toEqual('2009-2020');
 		utils.clickOnElement(component.find('.rdtNext span').at(0));
-		expect(component.find('.rdtSwitch').text()).toEqual('2020-2029');
+		expect(component.find('.rdtSwitch').text()).toEqual('2019-2030');
 	});
 
 	it('decrease decade', () => {
 		const date = new Date(2000, 0, 15, 2, 2, 2, 2),
 			component = utils.createDatetime({ initialViewMode: 'years', initialValue: date });
 
-		expect(component.find('.rdtSwitch').text()).toEqual('2000-2009');
+		expect(component.find('.rdtSwitch').text()).toEqual('1999-2010');
 		utils.clickOnElement(component.find('.rdtPrev span').at(0));
-		expect(component.find('.rdtSwitch').text()).toEqual('1990-1999');
+		expect(component.find('.rdtSwitch').text()).toEqual('1989-2000');
 		utils.clickOnElement(component.find('.rdtPrev span').at(0));
-		expect(component.find('.rdtSwitch').text()).toEqual('1980-1989');
+		expect(component.find('.rdtSwitch').text()).toEqual('1979-1990');
 	});
 
 	it('select month', () => {


### PR DESCRIPTION
**Fixed the incorrect range that is displayed in the year navigation header.**

### Description
- Fixed year navigation. 
- Modified Test cases for yearly navigation

### Motivation and Context
  * Why do you think this pull request should be merged?
      - This PR should be merged because when the date picker is in the years picker view, the range of years is displayed incorrectly.
  * Does it solve a problem, in that case what problem?
      - Yes it does solve a problem as mentioned above. Refer image for more clarity.
      
      
![image](https://user-images.githubusercontent.com/59045419/116977102-a6bcaf00-acdf-11eb-925e-58e7eaae155d.png)

In the above image, the range should be 2019 - 2030, but it is shown as 2020-2029

  * If these changes fixes an open issue, please provide a link to the issue here
      - Yes. [Issue](https://github.com/arqex/react-datetime/issues/635)

### Checklist
<!--
  The purpose of this checklist is for you to not forget changes you most likely should do. Look 
  through the following points, and put an "x" in all the boxes that apply. If you're unsure about 
  any of these points, then we'd recommend you to read the README. If something still is unclear 
  then don't hesitate to ask. We're here to help!
-->
```
[x] I have not included any built dist files (us maintainers do that prior to a new release)
[x] I have added tests covering my changes
[x] All new and existing tests pass
[ ] My changes required the documentation to be updated
[ ] I have updated the documentation accordingly
[ ] I have updated the TypeScript 1.8 type definitions accordingly
[ ] I have updated the TypeScript 2.0+ type definitions accordingly
```
