### PR TITLE
Call correct log method in DateTime component to prevent crash on invalid input

### DIFF
--- a/src/DateTime.js
+++ b/src/DateTime.js
@@ -531,9 +531,8 @@ export default class Datetime extends React.Component {
 	 * @public
 	 */
 	setViewDate( date ) {
-		let me = this;
 		let logError = function() {
-			return me.log( 'Invalid date passed to the `setViewDate` method: ' + date );
+			return log( 'Invalid date passed to the `setViewDate` method: ' + date );
 		};
 
 		if ( !date ) return logError();


### PR DESCRIPTION
### Description
<!-- Describe your changes in detail -->
This PR adjusts the code of the `DateTime` component to call the correct log method. At the moment, this code crashes the component if the `value` prop of the `DateTime` component does not match the expected format. See https://github.com/arqex/react-datetime/issues/801

### Motivation and Context

The `log` method was moved outside the class in https://github.com/arqex/react-datetime/commit/d4450038cd901f1e0f31bcd365448820f60c6f67#diff-cae892f0886b91915576f17fd54c818f7ef44b721a3885d4a742039f1c8cad03L557-R611
Unfortunately, the call this method inside of `setViewDate` was not adjusted. This causes the error described above.

### Checklist
<!--
  The purpose of this checklist is for you to not forget changes you most likely should do. Look 
  through the following points, and put an "x" in all the boxes that apply. If you're unsure about 
  any of these points, then we'd recommend you to read the README. If something still is unclear 
  then don't hesitate to ask. We're here to help!
-->
```
[x] I have not included any built dist files (us maintainers do that prior to a new release)
[ ] I have added tests covering my changes
[x] All new and existing tests pass
[ ] My changes required the documentation to be updated
  [ ] I have updated the documentation accordingly
  [ ] I have updated the TypeScript 1.8 type definitions accordingly
  [ ] I have updated the TypeScript 2.0+ type definitions accordingly
```

