### PR TITLE
Fix 'last day of prev month' selection

### DIFF
--- a/src/DateTime.js
+++ b/src/DateTime.js
@@ -337,7 +337,6 @@ export default class Datetime extends React.Component {
 		let currentView = state.currentView;
 		let updateOnView = this.getUpdateOn( this.getFormat('date') );
 		let viewDate = this.state.viewDate.clone();
-		console.log(e.target, this.viewToMethod[currentView]);
 
 		// Need to set month and year for days view (prev/next month)
 		if ( currentView === 'days' ) {

--- a/src/DateTime.js
+++ b/src/DateTime.js
@@ -337,17 +337,18 @@ export default class Datetime extends React.Component {
 		let currentView = state.currentView;
 		let updateOnView = this.getUpdateOn( this.getFormat('date') );
 		let viewDate = this.state.viewDate.clone();
+		console.log(e.target, this.viewToMethod[currentView]);
+
+		// Need to set month and year for days view (prev/next month)
+		if ( currentView === 'days' ) {
+			viewDate.month( parseInt( e.target.getAttribute('data-month'), 10 ) );
+			viewDate.year( parseInt( e.target.getAttribute('data-year'), 10 ) );
+		}
 
 		// Set the value into day/month/year
 		viewDate[ this.viewToMethod[currentView] ](
 			parseInt( e.target.getAttribute('data-value'), 10 )
 		);
-
-		// Need to set month and year will for days view (prev/next month)
-		if ( currentView === 'days' ) {
-			viewDate.month( parseInt( e.target.getAttribute('data-month'), 10 ) );
-			viewDate.year( parseInt( e.target.getAttribute('data-year'), 10 ) );
-		}
 
 		let update = {viewDate: viewDate};
 		if ( currentView === updateOnView ) {

--- a/test/__snapshots__/snapshots.spec.js.snap
+++ b/test/__snapshots__/snapshots.spec.js.snap
@@ -310,7 +310,7 @@ exports[`className: set to arbitraty value 1`] = `
               20
             </td>
             <td
-              className="rdtDay"
+              className="rdtDay rdtToday"
               data-month={11}
               data-value={21}
               data-year={2016}
@@ -319,7 +319,7 @@ exports[`className: set to arbitraty value 1`] = `
               21
             </td>
             <td
-              className="rdtDay rdtToday"
+              className="rdtDay"
               data-month={11}
               data-value={22}
               data-year={2016}
@@ -908,7 +908,7 @@ exports[`dateFormat set to true 1`] = `
               20
             </td>
             <td
-              className="rdtDay"
+              className="rdtDay rdtToday"
               data-month={11}
               data-value={21}
               data-year={2016}
@@ -917,7 +917,7 @@ exports[`dateFormat set to true 1`] = `
               21
             </td>
             <td
-              className="rdtDay rdtToday"
+              className="rdtDay"
               data-month={11}
               data-value={22}
               data-year={2016}
@@ -1402,7 +1402,7 @@ exports[`defaultValue: set to arbitrary value 1`] = `
               20
             </td>
             <td
-              className="rdtDay"
+              className="rdtDay rdtToday"
               data-month={11}
               data-value={21}
               data-year={2016}
@@ -1411,7 +1411,7 @@ exports[`defaultValue: set to arbitrary value 1`] = `
               21
             </td>
             <td
-              className="rdtDay rdtToday"
+              className="rdtDay"
               data-month={11}
               data-value={22}
               data-year={2016}
@@ -1896,7 +1896,7 @@ exports[`everything default: renders correctly 1`] = `
               20
             </td>
             <td
-              className="rdtDay"
+              className="rdtDay rdtToday"
               data-month={11}
               data-value={21}
               data-year={2016}
@@ -1905,7 +1905,7 @@ exports[`everything default: renders correctly 1`] = `
               21
             </td>
             <td
-              className="rdtDay rdtToday"
+              className="rdtDay"
               data-month={11}
               data-value={22}
               data-year={2016}
@@ -2381,7 +2381,7 @@ exports[`input input: set to false 1`] = `
               20
             </td>
             <td
-              className="rdtDay"
+              className="rdtDay rdtToday"
               data-month={11}
               data-value={21}
               data-year={2016}
@@ -2390,7 +2390,7 @@ exports[`input input: set to false 1`] = `
               21
             </td>
             <td
-              className="rdtDay rdtToday"
+              className="rdtDay"
               data-month={11}
               data-value={22}
               data-year={2016}
@@ -2875,7 +2875,7 @@ exports[`input input: set to true 1`] = `
               20
             </td>
             <td
-              className="rdtDay"
+              className="rdtDay rdtToday"
               data-month={11}
               data-value={21}
               data-year={2016}
@@ -2884,7 +2884,7 @@ exports[`input input: set to true 1`] = `
               21
             </td>
             <td
-              className="rdtDay rdtToday"
+              className="rdtDay"
               data-month={11}
               data-value={22}
               data-year={2016}
@@ -3369,7 +3369,7 @@ exports[`inputProps with className specified 1`] = `
               20
             </td>
             <td
-              className="rdtDay"
+              className="rdtDay rdtToday"
               data-month={11}
               data-value={21}
               data-year={2016}
@@ -3378,7 +3378,7 @@ exports[`inputProps with className specified 1`] = `
               21
             </td>
             <td
-              className="rdtDay rdtToday"
+              className="rdtDay"
               data-month={11}
               data-value={22}
               data-year={2016}
@@ -3864,7 +3864,7 @@ exports[`inputProps with disabled specified 1`] = `
               20
             </td>
             <td
-              className="rdtDay"
+              className="rdtDay rdtToday"
               data-month={11}
               data-value={21}
               data-year={2016}
@@ -3873,7 +3873,7 @@ exports[`inputProps with disabled specified 1`] = `
               21
             </td>
             <td
-              className="rdtDay rdtToday"
+              className="rdtDay"
               data-month={11}
               data-value={22}
               data-year={2016}
@@ -4359,7 +4359,7 @@ exports[`inputProps with name specified 1`] = `
               20
             </td>
             <td
-              className="rdtDay"
+              className="rdtDay rdtToday"
               data-month={11}
               data-value={21}
               data-year={2016}
@@ -4368,7 +4368,7 @@ exports[`inputProps with name specified 1`] = `
               21
             </td>
             <td
-              className="rdtDay rdtToday"
+              className="rdtDay"
               data-month={11}
               data-value={22}
               data-year={2016}
@@ -4854,7 +4854,7 @@ exports[`inputProps with placeholder specified 1`] = `
               20
             </td>
             <td
-              className="rdtDay"
+              className="rdtDay rdtToday"
               data-month={11}
               data-value={21}
               data-year={2016}
@@ -4863,7 +4863,7 @@ exports[`inputProps with placeholder specified 1`] = `
               21
             </td>
             <td
-              className="rdtDay rdtToday"
+              className="rdtDay"
               data-month={11}
               data-value={22}
               data-year={2016}
@@ -5349,7 +5349,7 @@ exports[`inputProps with required specified 1`] = `
               20
             </td>
             <td
-              className="rdtDay"
+              className="rdtDay rdtToday"
               data-month={11}
               data-value={21}
               data-year={2016}
@@ -5358,7 +5358,7 @@ exports[`inputProps with required specified 1`] = `
               21
             </td>
             <td
-              className="rdtDay rdtToday"
+              className="rdtDay"
               data-month={11}
               data-value={22}
               data-year={2016}
@@ -5819,15 +5819,16 @@ exports[`isValidDate: only valid if after yesterday 1`] = `
               20
             </td>
             <td
-              className="rdtDay rdtDisabled"
+              className="rdtDay rdtToday"
               data-month={11}
               data-value={21}
               data-year={2016}
+              onClick={[Function]}
             >
               21
             </td>
             <td
-              className="rdtDay rdtToday"
+              className="rdtDay"
               data-month={11}
               data-value={22}
               data-year={2016}
@@ -6312,7 +6313,7 @@ exports[`open set to false 1`] = `
               20
             </td>
             <td
-              className="rdtDay"
+              className="rdtDay rdtToday"
               data-month={11}
               data-value={21}
               data-year={2016}
@@ -6321,7 +6322,7 @@ exports[`open set to false 1`] = `
               21
             </td>
             <td
-              className="rdtDay rdtToday"
+              className="rdtDay"
               data-month={11}
               data-value={22}
               data-year={2016}
@@ -6806,7 +6807,7 @@ exports[`open set to true 1`] = `
               20
             </td>
             <td
-              className="rdtDay"
+              className="rdtDay rdtToday"
               data-month={11}
               data-value={21}
               data-year={2016}
@@ -6815,7 +6816,7 @@ exports[`open set to true 1`] = `
               21
             </td>
             <td
-              className="rdtDay rdtToday"
+              className="rdtDay"
               data-month={11}
               data-value={22}
               data-year={2016}
@@ -7300,7 +7301,7 @@ exports[`renderDay: specified 1`] = `
               020
             </td>
             <td
-              className="rdtDay"
+              className="rdtDay rdtToday"
               data-month={11}
               data-value={21}
               data-year={2016}
@@ -7309,7 +7310,7 @@ exports[`renderDay: specified 1`] = `
               021
             </td>
             <td
-              className="rdtDay rdtToday"
+              className="rdtDay"
               data-month={11}
               data-value={22}
               data-year={2016}
@@ -7794,7 +7795,7 @@ exports[`renderMonth: specified 1`] = `
               20
             </td>
             <td
-              className="rdtDay"
+              className="rdtDay rdtToday"
               data-month={11}
               data-value={21}
               data-year={2016}
@@ -7803,7 +7804,7 @@ exports[`renderMonth: specified 1`] = `
               21
             </td>
             <td
-              className="rdtDay rdtToday"
+              className="rdtDay"
               data-month={11}
               data-value={22}
               data-year={2016}
@@ -8288,7 +8289,7 @@ exports[`renderYear: specified 1`] = `
               20
             </td>
             <td
-              className="rdtDay"
+              className="rdtDay rdtToday"
               data-month={11}
               data-value={21}
               data-year={2016}
@@ -8297,7 +8298,7 @@ exports[`renderYear: specified 1`] = `
               21
             </td>
             <td
-              className="rdtDay rdtToday"
+              className="rdtDay"
               data-month={11}
               data-value={22}
               data-year={2016}
@@ -8782,7 +8783,7 @@ exports[`timeFormat set to false 1`] = `
               20
             </td>
             <td
-              className="rdtDay"
+              className="rdtDay rdtToday"
               data-month={11}
               data-value={21}
               data-year={2016}
@@ -8791,7 +8792,7 @@ exports[`timeFormat set to false 1`] = `
               21
             </td>
             <td
-              className="rdtDay rdtToday"
+              className="rdtDay"
               data-month={11}
               data-value={22}
               data-year={2016}
@@ -9265,7 +9266,7 @@ exports[`timeFormat set to true 1`] = `
               20
             </td>
             <td
-              className="rdtDay"
+              className="rdtDay rdtToday"
               data-month={11}
               data-value={21}
               data-year={2016}
@@ -9274,7 +9275,7 @@ exports[`timeFormat set to true 1`] = `
               21
             </td>
             <td
-              className="rdtDay rdtToday"
+              className="rdtDay"
               data-month={11}
               data-value={22}
               data-year={2016}
@@ -9759,7 +9760,7 @@ exports[`value: set to arbitrary value 1`] = `
               20
             </td>
             <td
-              className="rdtDay"
+              className="rdtDay rdtToday"
               data-month={11}
               data-value={21}
               data-year={2016}
@@ -9768,7 +9769,7 @@ exports[`value: set to arbitrary value 1`] = `
               21
             </td>
             <td
-              className="rdtDay rdtToday"
+              className="rdtDay"
               data-month={11}
               data-value={22}
               data-year={2016}
@@ -10253,7 +10254,7 @@ exports[`viewMode set to days 1`] = `
               20
             </td>
             <td
-              className="rdtDay"
+              className="rdtDay rdtToday"
               data-month={11}
               data-value={21}
               data-year={2016}
@@ -10262,7 +10263,7 @@ exports[`viewMode set to days 1`] = `
               21
             </td>
             <td
-              className="rdtDay rdtToday"
+              className="rdtDay"
               data-month={11}
               data-value={22}
               data-year={2016}
@@ -10747,7 +10748,7 @@ exports[`viewMode set to months 1`] = `
               20
             </td>
             <td
-              className="rdtDay"
+              className="rdtDay rdtToday"
               data-month={11}
               data-value={21}
               data-year={2016}
@@ -10756,7 +10757,7 @@ exports[`viewMode set to months 1`] = `
               21
             </td>
             <td
-              className="rdtDay rdtToday"
+              className="rdtDay"
               data-month={11}
               data-value={22}
               data-year={2016}
@@ -11241,7 +11242,7 @@ exports[`viewMode set to time 1`] = `
               20
             </td>
             <td
-              className="rdtDay"
+              className="rdtDay rdtToday"
               data-month={11}
               data-value={21}
               data-year={2016}
@@ -11250,7 +11251,7 @@ exports[`viewMode set to time 1`] = `
               21
             </td>
             <td
-              className="rdtDay rdtToday"
+              className="rdtDay"
               data-month={11}
               data-value={22}
               data-year={2016}
@@ -11735,7 +11736,7 @@ exports[`viewMode set to years 1`] = `
               20
             </td>
             <td
-              className="rdtDay"
+              className="rdtDay rdtToday"
               data-month={11}
               data-value={21}
               data-year={2016}
@@ -11744,7 +11745,7 @@ exports[`viewMode set to years 1`] = `
               21
             </td>
             <td
-              className="rdtDay rdtToday"
+              className="rdtDay"
               data-month={11}
               data-value={22}
               data-year={2016}

--- a/test/tests.spec.js
+++ b/test/tests.spec.js
@@ -236,6 +236,18 @@ describe('Datetime', () => {
 		expect(component.find('.rdtSwitch').text()).toEqual('February 2019');
 	});
 
+	it('click on first day of the next month', () => {
+		const component = utils.createDatetime({
+			initialViewMode: 'days',
+			initialValue: new Date(2019, 0, 1)
+		});
+
+		utils.openDatepicker(component);
+		utils.clickClassItem(component, '.rdtNew', 0);
+
+		expect(component.find('.form-control').getDOMNode().value).toEqual('02/01/2019 12:00 AM');
+	});
+
 	it('click on day of the prev month', () => {
 		const component = utils.createDatetime({
 			initialViewMode: 'days',
@@ -246,6 +258,18 @@ describe('Datetime', () => {
 		utils.clickClassItem(component, '.rdtOld', 1);
 		
 		expect(component.find('.rdtSwitch').text()).toEqual('December 2018');
+	});
+
+	it('click on last day of the prev month', () => {
+		const component = utils.createDatetime({
+			initialViewMode: 'days',
+			initialValue: new Date(2019, 0, 1)
+		});
+
+		utils.openDatepicker(component);
+		utils.clickClassItem(component, '.rdtOld', 1);
+
+		expect(component.find('.form-control').getDOMNode().value).toEqual('12/31/2018 12:00 AM');
 	});
 
 	it('sets CSS class on selected item (day)', () => {


### PR DESCRIPTION
### Description
Fix 'last day of prev month' date selection in DateTime's `_updateDate` method (fixes #804)

### Motivation and Context
Inside DateTime's `_updateDate` method, setting the `data-value` before the month/year causes unexpected behavior when a user selects the last day of the previous month. Switching the order resolves the issue.

### Checklist
```
[x ] I have not included any built dist files (us maintainers do that prior to a new release)
[x ] I have added tests covering my changes
[x ] All new and existing tests pass
[ ] My changes required the documentation to be updated
  [ ] I have updated the documentation accordingly
  [ ] I have updated the TypeScript 1.8 type definitions accordingly
  [ ] I have updated the TypeScript 2.0+ type definitions accordingly
```