### PR TITLE
Add closeOnTab to 2.0 typescript typings

### DIFF
--- a/typings/DateTime.d.ts
+++ b/typings/DateTime.d.ts
@@ -187,6 +187,10 @@ declare namespace ReactDatetimeClass {
          */
         strictParsing?: boolean;
         /*
+        When true and the input is focused, pressing the tab key will close the datepicker.
+        */
+        closeOnTab?: boolean;
+        /*
          When true, once the day has been selected, the react-datetime will be automatically closed.
          */
         closeOnSelect?: boolean;


### PR DESCRIPTION
### Description
Add closeOnTab to 2.0 typescript typings

### Motivation and Context
This prop was added to the 1.8 typings in this commit: https://github.com/arqex/react-datetime/commit/0787dc1cf3ad7e6e5f18c4686bc4ee4c0eed6738. Porting this over to the 2.0 typings.

### Checklist
```
[x] I have not included any built dist files (us maintainers do that prior to a new release)
[ ] I have added tests covering my changes
[ ] All new and existing tests pass
[ ] My changes required the documentation to be updated
  [ ] I have updated the documentation accordingly
  [ ] I have updated the TypeScript 1.8 type definitions accordingly
  [ ] I have updated the TypeScript 2.0+ type definitions accordingly
```
