### PR TITLE
Add a "browser" field so build tools can find UMD build

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "url": "https://github.com/arqex/react-datetime"
   },
   "main": "./dist/react-datetime.cjs.js",
+  "browser": "./dist/react-datetime.umd.js",
   "typings": "./typings/DateTime.d.ts",
   "files": [
     "css",


### PR DESCRIPTION
### Description
Right now, the `package.json` only indicates the presence of the CommonJS build of `react-datetime` (as `"main"`). This change exposes the UMD build via the `"browser"` field.

### Motivation and Context
Right now, Rollup loads the CJS version of `react-datetime` through [@rollup/plugin-commonjs](https://github.com/rollup/plugins/tree/master/packages/commonjs). That should work just fine, but there are some edge cases in the plugin -- [this one](https://github.com/rollup/plugins/issues/1046) in particular seems problematic for `react-datetime`.

I discovered all this by trying to import `react-datetime` in Vite and discovering that the library worked in development (where Vite implements its own esbuild-based CJS -> ESM transformation) but not in production (where Vite uses Rollup). Here's a [minimal repro](https://github.com/davidwallacejackson/repro/tree/cjs-vite).

Including ESM directly would be ideal, but webpack still lists ESM output support as "experimental" in their docs, and I'm assuming this project doesn't particularly want to migrate to another build tool. I tried this out in my local copy and it fixed the issue.

### Checklist
<!--
  The purpose of this checklist is for you to not forget changes you most likely should do. Look 
  through the following points, and put an "x" in all the boxes that apply. If you're unsure about 
  any of these points, then we'd recommend you to read the README. If something still is unclear 
  then don't hesitate to ask. We're here to help!
-->
```
[x] I have not included any built dist files (us maintainers do that prior to a new release)
[ ] I have added tests covering my changes
[x] All new and existing tests pass
[ ] My changes required the documentation to be updated
  [ ] I have updated the documentation accordingly
  [ ] I have updated the TypeScript 1.8 type definitions accordingly
  [ ] I have updated the TypeScript 2.0+ type definitions accordingly
```


<!--
  Is there anything in this template you think is confusing, unclear, redundant or just simply bad?
  Please let us know either via creating an issue or creating a PR with changes to it.
-->
