### PR TITLE
Make allowed earliest day selectable in DaysView

### DIFF
--- a/src/views/DaysView.js
+++ b/src/views/DaysView.js
@@ -102,7 +102,7 @@ export default class DaysView extends React.Component {
 			className += ' rdtToday';
 		}
 
-		if ( this.props.isValidDate(date) ) {
+		if ( this.props.isValidDate(date) || this.props.isValidDate(date.clone().endOf('day')) ) {
 			dayProps.onClick = this._setDate;
 		}
 		else {


### PR DESCRIPTION
If `isValidDate` is provided to set a range of allowed dates, the earliest day of the
range was not selectable in DaysView because it was set to the start of the day. User
would have to implement certain logic in `isValidDate` to make it selectable. This
change would make the earliest day selectable by default.

<!-- Provide a general summary of your changes in the *Title* above -->

### Description
<!-- Describe your changes in detail -->

### Motivation and Context
<!--
  * Why do you think this pull request should be merged?
  * Does it solve a problem, in that case what problem?
  * If these changes fixes an open issue, please provide a link to the issue here
-->

### Checklist
<!--
  The purpose of this checklist is for you to not forget changes you most likely should do. Look 
  through the following points, and put an "x" in all the boxes that apply. If you're unsure about 
  any of these points, then we'd recommend you to read the README. If something still is unclear 
  then don't hesitate to ask. We're here to help!
-->
```
[x] I have not included any built dist files (us maintainers do that prior to a new release)
[ ] I have added tests covering my changes
[ ] All new and existing tests pass
[ ] My changes required the documentation to be updated
  [ ] I have updated the documentation accordingly
  [ ] I have updated the TypeScript 1.8 type definitions accordingly
  [ ] I have updated the TypeScript 2.0+ type definitions accordingly
```


<!--
  Is there anything in this template you think is confusing, unclear, redundant or just simply bad?
  Please let us know either via creating an issue or creating a PR with changes to it.
-->
