### PR TITLE
Fix issue with caret snapping to end on intial keyboard edits of controlled date picker

### DIFF
--- a/src/DateTime.js
+++ b/src/DateTime.js
@@ -577,9 +577,8 @@ export default class Datetime extends React.Component {
 			update.selectedDate = null;
 		}
 
-		this.setState( update, () => {
-			this.props.onChange( localMoment.isValid() ? localMoment : this.state.inputValue );
-		});
+		this.setState( update );
+		this.props.onChange(localMoment.isValid() ? localMoment : value);
 	}
 
 	_onInputKeyDown = e => {


### PR DESCRIPTION
### Description
<!-- Describe your changes in detail -->
Eliminates use of callback on `setState` to call this.props.onChange which was causing an issue with caret position resetting when you initially keyboard edit a newly selected date (on a controlled date picker).

### Motivation and Context
<!--
  * Why do you think this pull request should be merged?
  * Does it solve a problem, in that case what problem?
  * If these changes fixes an open issue, please provide a link to the issue here
-->
This fixes the issue #831 

Keyboard edits to controlled datepicker is a very common use case. Currently for a date like 11/11/1988, if a user wants to change month `11` to month `9`, when to replace month `11`, the caret will snap to the end. This can get very annoying if a user needs to use the keyboard edits to quickly fix a date and they must do this many times throughout a session.

### Checklist
<!--
  The purpose of this checklist is for you to not forget changes you most likely should do. Look 
  through the following points, and put an "x" in all the boxes that apply. If you're unsure about 
  any of these points, then we'd recommend you to read the README. If something still is unclear 
  then don't hesitate to ask. We're here to help!
-->
```
[ x ] I have not included any built dist files (us maintainers do that prior to a new release)
[ ] I have added tests covering my changes
[ ] All new and existing tests pass
[ ] My changes required the documentation to be updated
  [ ] I have updated the documentation accordingly
  [ ] I have updated the TypeScript 1.8 type definitions accordingly
  [ ] I have updated the TypeScript 2.0+ type definitions accordingly
```


<!--
  Is there anything in this template you think is confusing, unclear, redundant or just simply bad?
  Please let us know either via creating an issue or creating a PR with changes to it.
-->
