### PR TITLE
Allow usage with react 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "license": "MIT",
   "peerDependencies": {
     "moment": "^2.16.0",
-    "react": "^16.5.0 || ^17.0.0"
+    "react": "^16.5.0 || ^17.0.0 || ^18.0.0"
   },
   "devDependencies": {
     "@babel/core": "7.7.4",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the *Title* above -->

### Description

Allow usage with react 18.

### Motivation and Context

Avoid: "react-datetime@3.1.1 requires a peer of react@^16.5.0 || ^17.0.0 but none is installed"

### Checklist

```
[x] I have not included any built dist files (us maintainers do that prior to a new release)
[-] I have added tests covering my changes
[x] All new and existing tests pass
[-] My changes required the documentation to be updated
  [ ] I have updated the documentation accordingly
  [ ] I have updated the TypeScript 1.8 type definitions accordingly
  [ ] I have updated the TypeScript 2.0+ type definitions accordingly
```


<!--
  Is there anything in this template you think is confusing, unclear, redundant or just simply bad?
  Please let us know either via creating an issue or creating a PR with changes to it.
-->
