### PR TITLE
Fixed 'selecting the 31st day of previous month' bug

### DIFF
--- a/src/DateTime.js
+++ b/src/DateTime.js
@@ -338,16 +338,16 @@ export default class Datetime extends React.Component {
 		let updateOnView = this.getUpdateOn( this.getFormat('date') );
 		let viewDate = this.state.viewDate.clone();
 
-		// Set the value into day/month/year
-		viewDate[ this.viewToMethod[currentView] ](
-			parseInt( e.target.getAttribute('data-value'), 10 )
-		);
-
 		// Need to set month and year will for days view (prev/next month)
 		if ( currentView === 'days' ) {
 			viewDate.month( parseInt( e.target.getAttribute('data-month'), 10 ) );
 			viewDate.year( parseInt( e.target.getAttribute('data-year'), 10 ) );
 		}
+
+		// Set the value into day/month/year
+		viewDate[ this.viewToMethod[currentView] ](
+			parseInt( e.target.getAttribute('data-value'), 10 )
+		);
 
 		let update = {viewDate: viewDate};
 		if ( currentView === updateOnView ) {

--- a/src/DateTime.js
+++ b/src/DateTime.js
@@ -349,9 +349,11 @@ export default class Datetime extends React.Component {
 			parseInt( e.target.getAttribute('data-value'), 10 )
 		);
 
+		let selectedDate = moment([parseInt(e.target.getAttribute('data-year'), 10), 
+			parseInt(e.target.getAttribute('data-month'), 10), parseInt(e.target.getAttribute('data-value'), 10)]);
 		let update = {viewDate: viewDate};
 		if ( currentView === updateOnView ) {
-			update.selectedDate = viewDate.clone();
+			update.selectedDate = selectedDate;
 			update.inputValue = viewDate.format( this.getFormat('datetime') );
 
 			if ( this.props.open === undefined && this.props.input && this.props.closeOnSelect ) {

--- a/src/DateTime.js
+++ b/src/DateTime.js
@@ -338,16 +338,16 @@ export default class Datetime extends React.Component {
 		let updateOnView = this.getUpdateOn( this.getFormat('date') );
 		let viewDate = this.state.viewDate.clone();
 
+		// Set the value into day/month/year
+		viewDate[ this.viewToMethod[currentView] ](
+			parseInt( e.target.getAttribute('data-value'), 10 )
+		);
+		
 		// Need to set month and year will for days view (prev/next month)
 		if ( currentView === 'days' ) {
 			viewDate.month( parseInt( e.target.getAttribute('data-month'), 10 ) );
 			viewDate.year( parseInt( e.target.getAttribute('data-year'), 10 ) );
 		}
-
-		// Set the value into day/month/year
-		viewDate[ this.viewToMethod[currentView] ](
-			parseInt( e.target.getAttribute('data-value'), 10 )
-		);
 
 		let selectedDate = moment([parseInt(e.target.getAttribute('data-year'), 10), 
 			parseInt(e.target.getAttribute('data-month'), 10), parseInt(e.target.getAttribute('data-value'), 10)]);
@@ -360,7 +360,7 @@ export default class Datetime extends React.Component {
 				this._closeCalendar();
 			}
 
-			this.props.onChange( viewDate.clone() );
+			this.props.onChange( selectedDate );
 		}
 		else {
 			this._showView( this.nextView[ currentView ], viewDate );


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the *Title* above -->

### Description
<!-- Describe your changes in detail -->
Fixed 'selecting the 31st of previous month' bug

### Motivation and Context
<!--
  * Why do you think this pull request should be merged?
  This pull request fixes the aforementioned bug.
 
  * Does it solve a problem, in that case what problem?
  Yes, it resolves a bug related to selecting the 31st day of a previous month giving the 1st day of that month on the datetimepicker.

  * If these changes fixes an open issue, please provide a link to the issue here
     * https://github.com/arqex/react-datetime/issues/844
     * https://github.com/arqex/react-datetime/issues/804
     * https://github.com/arqex/react-datetime/issues/744
-->

### Checklist
<!--
  The purpose of this checklist is for you to not forget changes you most likely should do. Look 
  through the following points, and put an "x" in all the boxes that apply. If you're unsure about 
  any of these points, then we'd recommend you to read the README. If something still is unclear 
  then don't hesitate to ask. We're here to help!
-->
```
[ ] I have not included any built dist files (us maintainers do that prior to a new release)
[ ] I have added tests covering my changes
[ ] All new and existing tests pass
[ ] My changes required the documentation to be updated
  [ ] I have updated the documentation accordingly
  [ ] I have updated the TypeScript 1.8 type definitions accordingly
  [ ] I have updated the TypeScript 2.0+ type definitions accordingly
```


<!--
  Is there anything in this template you think is confusing, unclear, redundant or just simply bad?
  Please let us know either via creating an issue or creating a PR with changes to it.
-->
