### PR TITLE
Fixed typings for React 19

### DIFF
--- a/typings/DateTime.d.ts
+++ b/typings/DateTime.d.ts
@@ -5,6 +5,7 @@
 //                 Karol Janyst <http://github.com/LKay>,
 //                 Javier Marquez <javi@arqex.com>
 
+import * as React from "react";
 import { Component, ChangeEvent, FocusEvent, FocusEventHandler } from 'react';
 import { Moment } from 'moment';
 
@@ -155,33 +156,33 @@ declare namespace ReactDatetimeClass {
          view of react-datetime, this way it's possible to wrap the original view adding our own markup or
          override it completely with our own code.
         */
-        renderView?: (viewMode: string, renderCalendar: Function) => JSX.Element;
+        renderView?: (viewMode: string, renderCalendar: Function) => React.JSX.Element;
         /*
          Customize the way that the days are shown in the day picker. The accepted function has
          the selectedDate, the current date and the default calculated props for the cell,
          and must return a React component. See appearance customization
          */
-        renderDay?: (props: any, currentDate: any, selectedDate: any) => JSX.Element;
+        renderDay?: (props: any, currentDate: any, selectedDate: any) => React.JSX.Element;
         /*
          Customize the way that the months are shown in the month picker.
          The accepted function has the selectedDate, the current date and the default calculated
          props for the cell, the month and the year to be shown, and must return a
          React component. See appearance customization
          */
-        renderMonth?: (props: any, month: number, year: number, selectedDate: any) => JSX.Element;
+        renderMonth?: (props: any, month: number, year: number, selectedDate: any) => React.JSX.Element;
         /*
          Customize the way that the years are shown in the year picker.
          The accepted function has the selectedDate, the current date and the default calculated
          props for the cell, the year to be shown, and must return a React component.
          See appearance customization
          */
-        renderYear?: (props: any, year: number, selectedDate: any) => JSX.Element;
+        renderYear?: (props: any, year: number, selectedDate: any) => React.JSX.Element;
         /*
          Replace the rendering of the input element. The accepted function has openCalendar
          (a function which opens the calendar) and the default calculated props for the input.
          Must return a React component or null.
          */
-        renderInput?: (props: any, openCalendar: Function, closeCalendar: Function) => JSX.Element;
+        renderInput?: (props: any, openCalendar: Function, closeCalendar: Function) => React.JSX.Element;
         /*
          Whether to use moment's strict parsing when parsing input.
          */


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the *Title* above -->

### Description
<!-- Describe your changes in detail -->

Replaced references to `JSX.Element` with `React.JSX.Element`, as mentioned in the React 19 upgrade guide here: https://react.dev/blog/2024/04/25/react-19-upgrade-guide#the-jsx-namespace-in-typescript

### Motivation and Context
<!--
  * Why do you think this pull request should be merged?
  * Does it solve a problem, in that case what problem?
  * If these changes fixes an open issue, please provide a link to the issue here
-->

React 19 no longer provides the `JSX.Element` type; instead, it is present at `React.JSX.Element`. (as seen in link above)

### Checklist
<!--
  The purpose of this checklist is for you to not forget changes you most likely should do. Look 
  through the following points, and put an "x" in all the boxes that apply. If you're unsure about 
  any of these points, then we'd recommend you to read the README. If something still is unclear 
  then don't hesitate to ask. We're here to help!
-->
```
[X] I have not included any built dist files (us maintainers do that prior to a new release)
[n/a] I have added tests covering my changes
[n/a] All new and existing tests pass
[ ] My changes required the documentation to be updated
  [ ] I have updated the documentation accordingly
  [ ] I have updated the TypeScript 1.8 type definitions accordingly
  [ ] I have updated the TypeScript 2.0+ type definitions accordingly
```

<!--
  Is there anything in this template you think is confusing, unclear, redundant or just simply bad?
  Please let us know either via creating an issue or creating a PR with changes to it.
-->
